### PR TITLE
Tamper check for daily/main/bytecode DNS setting

### DIFF
--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -873,6 +873,16 @@ class CVDUpdate:
                 else:
                     # We can't use DNS to see if our version is old.
                     # Use HTTP to pull just the CVD header to check.
+
+                    # First, make sure no one tampered with the DNS field for
+                    # main/daily/bytecode when using database.clamav.net
+                    if (('database.clamav.net' in self.config['dbs'][db]['url']) and
+                        (db == 'main.cvd' or db == 'daily.cvd' or db == 'bytecode.cvd')):
+                        self.logger.error(f'It appears that the "DNS field" in {self.config_path} for "{db}" was modified from the default.')
+                        self.logger.error(f'Updating {db} from database.clamav.net requires DNS for the version check in order to conserve bandwidth.')
+                        self.logger.error(f'Please restore the default settings for the "DNS field" and try again.')
+                        return CvdStatus.ERROR
+
                     advertised_version = self._query_cvd_version_http(db)
 
                 if advertised_version == 0:


### PR DESCRIPTION
CVD-Update allows for third party databases or additional databases to
be updated with version checks performed purely through HTTP. For daily,
main, and bytecode these MUST use DNS though, to save bandwidth.

This commit adds a tamper check to make sure that updates to daily,
main, and bytecode when using database.clamav.net use DNS for the
version check.