### PR TITLE
Added a way to auto update av definitions

### DIFF
--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -39,7 +39,7 @@ import coloredlogs
 from http.server import HTTPServer
 from RangeHTTPServer import RangeRequestHandler
 
-
+from cvdupdate import auto_updater
 import pkg_resources
 from cvdupdate.cvdupdate import CVDUpdate
 
@@ -200,8 +200,9 @@ def clean_all(config: str, verbose: bool):
 @cli.command("serve")
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--update-interval-seconds", "-U", type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
 @click.argument("port", type=int, required=False, default=8000)
-def serve(port: int, config: str, verbose: bool):
+def serve(port: int, config: str, verbose: bool, update_interval_seconds: int):
     """
     Serve up the database directory. Not a production quality server.
     Intended for testing purposes.
@@ -209,6 +210,7 @@ def serve(port: int, config: str, verbose: bool):
     m = CVDUpdate(config=config, verbose=verbose)
     os.chdir(str(m.db_dir))
     m.logger.info(f"Serving up {m.db_dir} on localhost:{port}...")
+    auto_updater.start(update_interval_seconds)
 
     RangeRequestHandler.protocol_version = 'HTTP/1.0'
     # TODO(danvk): pick a random, available port

--- a/cvdupdate/auto_updater.py
+++ b/cvdupdate/auto_updater.py
@@ -1,0 +1,25 @@
+from threading import Event, Thread
+
+from cvdupdate.cvdupdate import CVDUpdate
+
+def start(interval: int) -> None:
+    """Spawn a thread to update the AV db after "interval" seconds
+    :param interval: the interval in seconds between 2 updates of the db
+    """
+    if interval > 0:
+        Thread(target=_update, daemon=True, args=[interval]).start()
+
+
+def _update(interval: int) -> None:
+    """Don't call this directly
+
+    Updates the AV db after every "interval" seconds when it was started
+    :param interval: the interval in seconds between 2 updates of the db
+    """
+    ticker = Event()
+    m = CVDUpdate()
+    m.logger.info(f"Updating the database every {interval} seconds")
+    while not ticker.wait(interval):
+        errors = m.db_update(debug_mode=True)
+        if errors > 0:
+            m.logger.error("Failed to fetch updates from ClamAV databases")


### PR DESCRIPTION
Hi cvdupdate team,

We're currently using your lib with our clamav setup and we found that it was inconvenient for us to run crons, so we implemented an optional updater that can run beside the server. We didn't change the current behaviour as everything is optional so current users won't see a difference if they don't want the feature.

## What got added
- `auto_updater.py`: Enables starting definitions updates after a certain interval. This is disabled if the interval is 0.
- A call to the `auto_updater.start(interval: int)` method in the `cvd serve` call. This is parametrized with `--update-interval-seconds`, a `INT` option in `click` which by default disables updates.

Thanks for your time!

_PS: If you want me to edit the README, I'll be glad to do so_
