### PR TITLE
Change CVD to *only* delete signatures it manages.

### DIFF
--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -255,12 +255,12 @@ class CVDUpdate:
 
     def clean_dbs(self):
         """
-        Delete all files in the database directory.
+        Delete cvd controlled files in the database directory.
         """
-        self.logger.info(f"Deleting databases...")
-        dbs = self.db_dir.glob('*')
+        dbs = self.config['dbs'].keys()
         for db in dbs:
-            os.remove(str(db))
+            cvddb = str(self.db_dir) + "/" + db
+            os.remove(cvddb)
             self.logger.info(f"Deleted: {db}")
 
     def clean_logs(self):


### PR DESCRIPTION
Good day
I would like to report and make a pull request for cvdupdate.

What we found is.
If cvdupdate co-shares a folder (in this case '/var/lib/clamav' ) with any third party signatures or files, on cleanup, cvdupdate will try to remove files it does not need too.
e.g.
clamav@mirror:~$ /opt/cvdupdate/bin/cvd clean all
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleting databases...
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleted: /var/lib/clamav/malware.expert.hdb
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleted: /var/lib/clamav/.bash_history
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleted: /var/lib/clamav/rfxn.ndb
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleted: /var/lib/clamav/shelter.ldb
2021-09-15 11:40:40 cvdupdate-1.0.2 INFO Deleted: /var/lib/clamav/daily-26290.cdiff

Please will you consider my pull request.

Many thanks
Kind Regards
Brent Clark