### PR TITLE
Cvd continues even if  main signatures is missing

### DIFF
--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -299,12 +299,12 @@ class CVDUpdate:
 
     def clean_dbs(self):
         """
-        Delete all files in the database directory.
+        Delete cvd controlled files in the database directory.
         """
-        self.logger.info(f"Deleting databases...")
-        dbs = self.db_dir.glob('*')
+        dbs = self.config['dbs'].keys()
         for db in dbs:
-            os.remove(str(db))
+            cvddb = str(self.db_dir) + "/" + db
+            os.remove(cvddb)
             self.logger.info(f"Deleted: {db}")
 
     def clean_logs(self):

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -303,9 +303,33 @@ class CVDUpdate:
         """
         dbs = self.state['dbs'].keys()
         for db in dbs:
-            cvddb = str(self.db_dir / db)
-            os.remove(cvddb)
-            self.logger.info(f"Deleted: {db}")
+            cvddb = self.db_dir / db
+            if cvddb.exists():
+                try:
+                    self.logger.info(f"Deleting: {db}")
+                    os.remove(str(cvddb))
+                except Exception as exc:
+                    self.logger.debug(f"Tried to remove {db}")
+                    raise exc
+
+        # Remove / clear all CDIFFs
+        cdiff_files = self.db_dir.glob('*.cdiff')
+        for cdiff in cdiff_files:
+            try:
+                self.logger.info(f"Deleting CDIFF: {cdiff.name}")
+                os.remove(str(cdiff))
+            except Exception as exc:
+                self.logger.debug(f"Tried to remove cdiffs.")
+
+        # Config cleanup
+        for db in dbs:
+            self.state['dbs'][db]['CDIFFs'] = []
+            self.state['dbs'][db]['last modified'] = 0
+            self.state['dbs'][db]['last checked'] = 0
+            self.state['dbs'][db]['local version'] = 0
+
+        # Save config
+        self._save_config()
 
     def clean_logs(self):
         """


### PR DESCRIPTION
Good day
I would like to report and make a pull request for cvdupdate.

What we found is.
If the main / actual signature is missing (i.e. accidentally and manually removed) from the db dir, cvdupdate just continue with the cdiff(s) and ignore the fact that the main is missing.
This work will first ensure and download the main signature.

You can find the example here:
https://pastebin.com/raw/Kg4YZ6AM

Please will you consider my pull request to ensure signature integrity. 

Many thanks
Kind Regards
Brent Clark