### PR TITLE
Add docker container build instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+.mypy_cache
+.pytest_cache
+.vscode
+cvdupdate.egg-info
+/build
+/dist
+/tests
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3-slim
 RUN apt-get -y update \
     && apt-get -y --no-install-recommends install cron gosu \
     && rm -rf /var/lib/apt/lists/*
-ADD . /dist
-RUN pip install /dist
+COPY . /dist
+RUN pip install --no-cache-dir /dist
 ENTRYPOINT [ "/dist/scripts/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3-slim
+RUN apt-get -y update \
+    && apt-get -y --no-install-recommends install cron \
+    && rm -rf /var/lib/apt/lists/*
+ADD . /dist
+RUN pip install /dist
+ENTRYPOINT [ "/dist/scripts/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-slim
 RUN apt-get -y update \
-    && apt-get -y --no-install-recommends install cron \
+    && apt-get -y --no-install-recommends install cron gosu \
     && rm -rf /var/lib/apt/lists/*
 ADD . /dist
 RUN pip install /dist

--- a/README.md
+++ b/README.md
@@ -270,23 +270,35 @@ Build docker image
 docker build . --tag cvdupdate:latest
 ```
 
-Run image, that will automaticly update databases in folder `/srv/cvdupdate`
+Run image, that will automaticly update databases in folder `/srv/cvdupdate` and write logs to `/var/log/cvdupdate`
 
 ```bash
 docker run -d \
-  -v /srv/cvdupdate:/root/.cvdupdate/database \
+  -v /srv/cvdupdate:/cvdupdate/database \
+  -v /var/log/cvdupdate:/cvdupdate/logs \
+  cvdupdate:latest
+```
+
+Run image, that will automaticly update databases in folder `/srv/cvdupdate`, write logs to `/var/log/cvdupdate` and set owner of files to user with ID 1000
+
+```bash
+docker run -d \
+  -v /srv/cvdupdate:/cvdupdate/database \
+  -v /var/log/cvdupdate:/cvdupdate/logs \
+  -e USER_ID=1000 \
   cvdupdate:latest
 ```
 
 Default update interval is `30 */4 * * *` (see [Cron Example](#cron-example))
 
-You may pass custum update interval in environment variable `CRON`
+You may pass custom update interval in environment variable `CRON`
 
 For example - update every day in 00:00
 
 ```bash
 docker run -d \
-  -v /srv/cvdupdate:/root/.cvdupdate/database \
+  -v /srv/cvdupdate:/cvdupdate/database \
+  -v /var/log/cvdupdate:/cvdupdate/logs \
   -e CRON='0 0 * * *' \
   cvdupdate:latest
   ```

--- a/README.md
+++ b/README.md
@@ -262,6 +262,35 @@ You can test it by running `freshclam` or `freshclam.exe` locally, where you've 
 DatabaseMirror http://localhost:8000
 ```
 
+### Use docker
+
+Build docker image
+
+```bash
+docker build . --tag cvdupdate:latest
+```
+
+Run image, that will automaticly update databases in folder `/srv/cvdupdate`
+
+```bash
+docker run -d \
+  -v /srv/cvdupdate:/root/.cvdupdate/database \
+  cvdupdate:latest
+```
+
+Default update interval is `30 */4 * * *` (see [Cron Example](#cron-example))
+
+You may pass custum update interval in environment variable `CRON`
+
+For example - update every day in 00:00
+
+```bash
+docker run -d \
+  -v /srv/cvdupdate:/root/.cvdupdate/database \
+  -e CRON='0 0 * * *' \
+  cvdupdate:latest
+  ```
+
 ## Contribute
 
 We'd love your help. There are many ways to contribute!

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+if [ $# -eq 0 ]; then
+    set -e
+    SCRIPT_PATH=$(readlink -f "$0")
+    echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
+
+    # Add crontab entry and start cron
+    echo "Adding crontab entry"
+    crontab -l | {
+        cat
+        echo "${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+        echo "@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+    } | crontab -
+    cron -f
+else
+    exec "$@"
+fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,16 +1,30 @@
 #!/bin/bash
 if [ $# -eq 0 ]; then
     set -e
+    USER_ID="${USER_ID:-0}"
     SCRIPT_PATH=$(readlink -f "$0")
     echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
-
-    # Add crontab entry and start cron
     echo "Adding crontab entry"
-    crontab -l | {
-        cat
-        echo "${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-        echo "@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-    } | crontab -
+    if [ "${USER_ID}" -ne "0" ]; then
+        echo "Creating user with ID ${USER_ID}"
+        useradd --create-home --home-dir /cvdupdate --uid "${USER_ID}" cvdupdate
+        gosu cvdupdate cvdupdate config set --logdir /cvdupdate/logs
+        gosu cvdupdate cvdupdate config set --dbdir /cvdupdate/database
+        crontab -l | {
+            cat
+            echo "${CRON:-"30 */4 * * *"} /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+            echo "@reboot /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+        } | crontab -
+    else
+        mkdir -p /cvdupdate/{logs,database}
+        cvdupdate config set --logdir /cvdupdate/logs
+        cvdupdate config set --dbdir /cvdupdate/database
+        crontab -l | {
+            cat
+            echo "${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+            echo "@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+        } | crontab -
+    fi
     cron -f
 else
     exec "$@"

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
+USER_ID="${USER_ID:-0}"
+SCRIPT_PATH=$(readlink -f "$0")
+echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
+if [ "${USER_ID}" -ne "0" ]; then
+    echo "Creating user with ID ${USER_ID}"
+    useradd --create-home --home-dir /cvdupdate --uid "${USER_ID}" cvdupdate
+    gosu cvdupdate cvdupdate config set --logdir /cvdupdate/logs
+    gosu cvdupdate cvdupdate config set --dbdir /cvdupdate/database
+else
+    mkdir -p /cvdupdate/{logs,database}
+    cvdupdate config set --logdir /cvdupdate/logs
+    cvdupdate config set --dbdir /cvdupdate/database
+fi
+
 if [ $# -eq 0 ]; then
     set -e
-    USER_ID="${USER_ID:-0}"
-    SCRIPT_PATH=$(readlink -f "$0")
-    echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
+
     echo "Adding crontab entry"
     if [ "${USER_ID}" -ne "0" ]; then
-        echo "Creating user with ID ${USER_ID}"
-        useradd --create-home --home-dir /cvdupdate --uid "${USER_ID}" cvdupdate
-        gosu cvdupdate cvdupdate config set --logdir /cvdupdate/logs
-        gosu cvdupdate cvdupdate config set --dbdir /cvdupdate/database
         crontab -l | {
             cat
             echo "${CRON:-"30 */4 * * *"} /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
             echo "@reboot /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
         } | crontab -
     else
-        mkdir -p /cvdupdate/{logs,database}
-        cvdupdate config set --logdir /cvdupdate/logs
-        cvdupdate config set --dbdir /cvdupdate/database
         crontab -l | {
             cat
             echo "${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
@@ -27,5 +32,9 @@ if [ $# -eq 0 ]; then
     fi
     cron -f
 else
-    exec "$@"
+    if [ "${USER_ID}" -ne "0" ]; then
+        exec gosu cvdupdate "$@"
+    else
+        exec "$@"
+    fi
 fi

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -5,6 +5,7 @@ echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
 if [ "${USER_ID}" -ne "0" ]; then
     echo "Creating user with ID ${USER_ID}"
     useradd --create-home --home-dir /cvdupdate --uid "${USER_ID}" cvdupdate
+    chown -R "${USER_ID}" /cvdupdate
     gosu cvdupdate cvdupdate config set --logdir /cvdupdate/logs
     gosu cvdupdate cvdupdate config set --dbdir /cvdupdate/database
 else


### PR DESCRIPTION
Added Dockerfile, instructions how to use docker container in README.md.

Docker container is based on `python:3-slim` docker image with installed cron, running in foreground.
