### PR TITLE
Add setuptools to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setuptools.setup(
         "requests",
         "dnspython>=2.1.0",
         "rangehttpserver",
+        "setuptools",
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
cvdupdate uses the pkg_resources module (provided by setuptools) at runtime so setuptools should be a dependency.

See https://setuptools.pypa.io/en/latest/pkg_resources.html

The usages are:
* https://github.com/Cisco-Talos/cvdupdate/blob/cvdupdate-1.1.1/cvdupdate/cvdupdate.py#L28
* https://github.com/Cisco-Talos/cvdupdate/blob/cvdupdate-1.1.1/cvdupdate/__main__.py#L43

This PR addresses the runtime failure of `cvd` with this error:
```
$ cvd config set --dbdir "$(pwd)/database"
Traceback (most recent call last):
  File "/usr/local/bin/cvd", line 5, in <module>
    from cvdupdate.__main__ import cli
  File "/usr/local/lib/python3.12/site-packages/cvdupdate/__main__.py", line 42, in <module>
    from cvdupdate import auto_updater
  File "/usr/local/lib/python3.12/site-packages/cvdupdate/auto_updater.py", line 3, in <module>
    from cvdupdate.cvdupdate import CVDUpdate
  File "/usr/local/lib/python3.12/site-packages/cvdupdate/cvdupdate.py", line 28, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```