### PR TITLE
Minor improvement to .sign file update behavior + Bump version to 1.2.0 and update the release notes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,62 +8,89 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
-## Unreleased
+## Version 1.2.0
 
-🐛 Replaced deprecated `pkg_resources` usage with `importlib.metadata` to avoid
-  deprecation warnings on Python 3.12+.
+- ➕ Support for downloading CVD and CDIFF digital signatures.
+
+  ClamAV 1.5.0 introduced a feature to verify the authenticity of CVD signature
+  archives and CDIFF signature archive patch files with an external digital
+  signature in support of using ClamAV within FIPS-enabled environments.
+
+  CVD Update will now download the `.sign` files to accompany each `.cvd` and
+  `.cdiff` file.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/72)
+
+- 🛡 Migrate from unmaintained "coloredlogs" dependency to "colorlog".
+  Work courtesy of Joel Esler.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/71)
+
+- 🌌 Improve the `cvdupdate` package version check to support alternative
+  package distributions and to enable signature updates even if the version
+  check fails.
+  Work courtesy of Joel Esler.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/73)
 
 ## Version 1.1.3
 
-🐛 Fixed CVD-Update version check in PyPI package repository on startup.
+- 🐛 Fixed CVD-Update version check in PyPI package repository on startup.
   Work courtesy of Steve Mays.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/67
 
-🌌 Info-level and Debug-level messages will now go to stdout instead of stderr.
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/67)
+
+- 🌌 Info-level and Debug-level messages will now go to stdout instead of
+  stderr.
   Work courtesy of GitHub user backbord.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/65
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/65)
 
 ## Version 1.1.2
 
-➕ Added a Docker Compose file to make it easier to host a private mirror.
+- ➕ Added a Docker Compose file to make it easier to host a private mirror.
   The Docker Compose environment runs two containers:
   1. CVD-Update.
   2. An Apache webserver to host the private mirror.
 
   Improvement courtesy of Mark Petersen.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/61
 
-🐛 Fixed the CVD-Update Python package so it installs the `setuptools`
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/61)
+
+- 🐛 Fixed the CVD-Update Python package so it installs the `setuptools`
   dependency. This fixes a runtime error on some systems.
   Fix courtesy of Craig Andrews.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/59
 
-🐛 Added missing documentation for `cvd add` command to the Readme.
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/59)
+
+- 🐛 Added missing documentation for `cvd add` command to the Readme.
   Fix courtesy of Kim Oliver Drechsel.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/58
 
-➕ Added retries in case the DNS TXT query fails.
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/58)
+
+- ➕ Added retries in case the DNS TXT query fails.
   Fix courtesy of backbord.
-  - GitHub Pull-Request: https://github.com/Cisco-Talos/cvdupdate/pull/50
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/50)
 
 ## Version 1.1.1
 
-🐛 Fixed an issue where the `.cdiff` files were only downloaded when updating a
-  `.cvd` and not when downloading the `.cvd` for the first time.
+- 🐛 Fixed an issue where the `.cdiff` files were only downloaded when updating
+  a `.cvd` and not when downloading the `.cvd` for the first time.
 
-🐛 Fixed an issue where `cvd update` crashes if the DNS query fails, rather
+- 🐛 Fixed an issue where `cvd update` crashes if the DNS query fails, rather
   than printing a helpful error message and exiting.
 
-🐛 Fixed support for CVD Update on Windows 🪟. In prior versions, the DNS query
-  was failing if a DNS server was not specified manually. Now it will try to use
+- 🐛 Fixed support for CVD Update on Windows 🪟. In prior versions, the DNS
+  query was failing if a DNS server was not specified manually. Now it will try
   OpenDNS servers if no DNS server is specified.
 
-➕ Added Python dependencies to the Readme to help users that are unable to
+- ➕ Added Python dependencies to the Readme to help users that are unable to
   install using `pip`.
 
 ## Version 1.1.0
 
-➕ CVD-Update can now get the DNS nameserver IP from an environment variable.
+- ➕ CVD-Update can now get the DNS nameserver IP from an environment variable.
 
   Specify the IP address of the nameserver in the environment variable
   `CVDUPDATE_NAMESERVER` to ensure said nameserver is used when querying the
@@ -74,7 +101,7 @@
 
   Feature courtesy of Philippe Ballandras.
 
-➕ CVD-Update can now accept multiple DNS nameservers from the `nameserver`
+- ➕ CVD-Update can now accept multiple DNS nameservers from the `nameserver`
   config option, or from the `CVDUPDATE_NAMESERVER` environment variable.
 
   To set multiple DNS nameservers, specify the `nameserver` config option or the
@@ -87,15 +114,15 @@
 
   Feature courtesy of Michael Callahan.
 
-🐛 In prior versions, CVD-Update would assume that a CVD file exists because it
-  is listed in the `config.json` "dbs" record. So if you delete that file by
+- 🐛 In prior versions, CVD-Update would assume that a CVD file exists because
+  it is listed in the `config.json` "dbs" record. So if you delete that file by
   accident and try to update, it would not notice and would instead claim that
   it is up-to-date. In this release, CVD-Update will detect that a deleted file
   is missing from the database directory and will re-download it.
 
   Fix courtesy of Brent Clark.
 
-🌌 CVD-Update will no longer remove extra files from the database directory
+- - 🌌 CVD-Update will no longer remove extra files from the database directory
   when you run `cvd clean dbs`. It will only remove those file managed by the
   CVD-Update tool.
 
@@ -105,7 +132,7 @@
 
   Improvement courtesy of Brent Clark.
 
-🌌 CVD-Update now stores the database state information separately from the
+- 🌌 CVD-Update now stores the database state information separately from the
   configuration information. If you're upgrading from CVD-Update version 1.0.2,
   your `config.json` file will be migrated automatatically when you run
   `cvd update` to split it into `config.json` + `state.json`.
@@ -123,17 +150,17 @@ Special thanks to:
 
 ## Version 1.0.2
 
-🐛 Fixed a Python 3.6 compatibility issue in the package version check.
+- 🐛 Fixed a Python 3.6 compatibility issue in the package version check.
 
 ## Version 1.0.1
 
-🐛 Fixed a bug where the CVD-Update PyPI package version check prints an
+- 🐛 Fixed a bug where the CVD-Update PyPI package version check prints an
   error message on some systems where `pip` doesn't return the available
   package versions.
 
 ## Version 1.0.0
 
-➕ Added a check to make sure that version check for the daily, main, and
+- ➕ Added a check to make sure that version check for the daily, main, and
   bytecode databases are done using DNS when downloading from
   `database.clamav.net`.
 
@@ -146,47 +173,45 @@ Special thanks to:
   should reduce the chance that the user is rate-limited or blocked by the CDN
   for downloading these files too frequently.
 
-➕ Added a PyPI package version check when running `cvd update` to encourage
+- ➕ Added a PyPI package version check when running `cvd update` to encourage
   users to update when there is a new version.
 
-🐛 CVD-Update now requires dnspython version 2.1.0 or newer. This fixes
+- 🐛 CVD-Update now requires dnspython version 2.1.0 or newer. This fixes
   compatibility issues with older dnspython versions.
   Special thanks to Byron Collins for this fix.
 
-🐛 Added explicit timeout for the DNS resolver. This fixes a DNS query issue
+- 🐛 Added explicit timeout for the DNS resolver. This fixes a DNS query issue
   on some systems.
   Special thanks to Colin Tilley for this fix.
 
-🐛 Fixed a bug when pruning older CDIFFs where the CDIFF files were already
+- 🐛 Fixed a bug when pruning older CDIFFs where the CDIFF files were already
   removed by the user.
 
 ## Version 0.3.0
 
-➕ `cvd update` will now retry up to 3x if the downloaded content length is
+- ➕ `cvd update` will now retry up to 3x if the downloaded content length is
   less than the content-length in the response header. This is to resolve
   issues with flakey connections.
 
-➕ `cvd update` now has a `--debug-mode` (`-D`) option to print out the HTTP
+- ➕ `cvd update` now has a `--debug-mode` (`-D`) option to print out the HTTP
   headers to debug issues with the update process.
 
-➕ The update process will now save the DNS TXT record containing version
+- ➕ The update process will now save the DNS TXT record containing version
   metadata as `dns.txt` in the database directory so it may be served by the
   private mirror.
 
   Some common check scripts (on clients) use `dns.txt` to check if ClamAV is up
   to date instead of using DNS or the HTTP CVD-header check.
 
-🌌 CVDUpdate will now have a unique User-Agent: `CVDUPDATE/<version> (<UUID>)`
+- 🌌 CVDUpdate will now have a unique User-Agent: `CVDUPDATE/<version> (<UUID>)`
 
   The UUID is randomly generated, and will help with anonymous usage metrics.
 
-🐛 Fixed a couple issues with the `cvd update <specific database>` option.
+- 🐛 Fixed a couple issues with the `cvd update <specific database>` option.
 
 ## Version 0.2.0
 
-### Added
-
-➕ Two ways to set a custom DNS nameserver.
+- ➕ Two ways to set a custom DNS nameserver.
   DNS queries are required to check the latest available database versions.
 
   1. Set the nameserver in the config. Eg:
@@ -202,11 +227,9 @@ Special thanks to:
      CVDUPDATE_NAMESERVER="208.67.222.222" cvd update
      ```
 
-🐛 Error handling so `dns update` fails if a DNS query fails.
+  Special thanks to Michael Callahan for this feature.
 
-### Acknowledgements
-
-Special thanks to Michael Callahan for adding the custom nameserver feature.
+- 🐛 Error handling so `dns update` fails if a DNS query fails.
 
 ## Version 0.1.0
 

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -10,7 +10,7 @@ for the purposes of hosting your own database mirror.
 """
 
 _copyright = """
-Copyright (C) 2021-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 """
 
 """

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -757,6 +757,15 @@ class CVDUpdate:
             # Not modified since IMS. We have the latest version.
             version = self.state['dbs'][db]['local version']
             self.logger.info(f"{db} not-modified since: {ims} (local version {version})")
+
+            # Check for .cvd.sign.
+            # it won't download if we already have it.
+            self._download_sign_file_for(
+                db,
+                url,
+                last_modified=0,
+                version=version)
+
             return CvdStatus.NO_UPDATE
 
         elif response.status_code == 429:
@@ -904,6 +913,11 @@ class CVDUpdate:
             ext = name_parts[-1]
             sign_file = f"{file_name}-{version}.{ext}.sign"
 
+        # check if we already have it.
+        if (self.db_dir / sign_file).exists():
+            self.logger.debug(f"We already have {sign_file}. Skipping...")
+            return CvdStatus.NO_UPDATE
+
         # now remove the old file name from the file_url and add the new sign file name
         base_url = file_url.rsplit('/', 1)[0]
         url = f"{base_url}/{sign_file}"
@@ -979,6 +993,17 @@ class CVDUpdate:
         if local_version >= available_version:
             # Oh! We're already up to date, don't worry about it.
             self.logger.info(f"{db} is up-to-date. Version: {local_version}")
+
+            db_url = self.state['dbs'][db]['url']
+
+            # Check for the .cvd.sign file, just in case we don't have that yet.
+            # It won't download if we already have it.
+            self._download_sign_file_for(
+                db,
+                db_url,
+                last_modified=0,
+                version=available_version)
+
             return CvdStatus.NO_UPDATE
 
         elif local_version == 0:

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2021-2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
 
 This module provides a tool to download and update clamav databases and database
 patch files (CDIFFs) for the purposes of hosting your own database mirror.

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cvdupdate",
-    version="1.1.3",
+    version="1.2.0",
     author="The ClamAV Team",
     author_email="clamav-bugs@external.cisco.com",
-    copyright="Copyright (C) 2022 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
+    copyright="Copyright (C) 2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",
     description="ClamAV Private Database Mirror Updater Tool",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
[Download missing .sign files even if .cvd doesn't need to be updated](https://github.com/Cisco-Talos/cvdupdate/pull/75/commits/7d267f7843c909495febf74041ea999d9628fdf5)
UX improvement for .sign file updates so it pulls missing .sign files
even if you don't need to download the associated cvd.
This may be meaningful for folks who have been running cvdupdate for a
while and already have main.cvd and bytecode.cvd, because we do not
publish those often.

[Bump version to 1.2.0 and update the release notes](https://github.com/Cisco-Talos/cvdupdate/pull/75/commits/c43c9977e3ea35ae95c913c11a79749dc1a44053)