### PR TITLE
Add proxy auth support and status/metrics commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,31 @@
 
 ## Version 1.3.0
 
+- ➕ Added authenticated proxy support. Proxy settings can be provided through
+  environment variables (`CVDUPDATE_PROXY_URL`, `CVDUPDATE_PROXY_USER`,
+  `CVDUPDATE_PROXY_PASS`) or with `cvd config set` (`--proxy-url`,
+  `--proxy-user`, `--proxy-pass`). Credentials are embedded in the proxy URL so
+  the `Proxy-Authorization` header is sent, and they are redacted from logs and
+  from `cvd config show`. Feature courtesy of Nik Kale.
+
+  Closes #7, #9.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/81)
+
+- ➕ Added a `cvd health` command that reports the health and currency of
+  downloaded databases, including per-database version comparison, file age,
+  and cooldown state. Pass `--json` for machine-readable output and `--check`
+  for a non-zero exit code when databases are not healthy, for scripted health
+  checks. Feature courtesy of Nik Kale.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/81)
+
+- ➕ Added a `cvd metrics` command that outputs database status as
+  Prometheus-format metrics, either once to stdout or from a persistent HTTP
+  server with `--serve` for scraping. Feature courtesy of Nik Kale.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/81)
+
 - ➕ Added a `cvd status` command (alias `s`) that reports the status of all
   databases, or of a single database when given a name. Pass `--json` for
   machine-readable output. The `cvd list` command (alias `ls`) now prints just

--- a/README.md
+++ b/README.md
@@ -184,9 +184,45 @@ export https_proxy
 cvd update -V
 ```
 
-> _Disclaimer_: CVD-Update doesn't support proxies that require authentication at this time. If your network admin allows it, you may be able to work around it by updating your proxy to allow HTTP requests through unauthenticated if the User-Agent matches your specific CVD-Update user agent. The CVD-Update User-Agent follows the form `CVDUPDATE/<version> (<uuid>)` where the `uuid` is unique to your installation and can be found in the `~/.cvdupdate/state.json` file (or `~/.cvdupdate/config.json` for cvdupdate <=1.0.2). See https://github.com/Cisco-Talos/cvdupdate/issues/9 for more details.
->
-> Adding support for proxy authentication is a ripe opportunity for a community contribution to the project.
+### Using an authenticated proxy
+
+For proxies that require authentication, CVD-Update accepts proxy credentials
+through environment variables or the config file. Credentials are embedded in
+the proxy URL so the `Proxy-Authorization` header is sent, and they are redacted
+from logs and from `cvd config show`.
+
+Using environment variables:
+
+```bash
+CVDUPDATE_PROXY_URL="http://proxy.example.com:8080" \
+CVDUPDATE_PROXY_USER="myuser" \
+CVDUPDATE_PROXY_PASS="mypassword" \
+cvd update -V
+```
+
+Or store them in the config file:
+
+```bash
+cvd config set --proxy-url http://proxy.example.com:8080
+cvd config set --proxy-user myuser
+cvd config set --proxy-pass         # prompts for the password
+```
+
+Environment variables take precedence over config file settings, and special
+characters in credentials are URL-encoded automatically.
+
+> _Security note_: credentials passed with `--proxy-user`/`--proxy-pass` are
+> stored **in plaintext** in `config.json` (the file is created with `0600`
+> permissions, i.e. readable only by your user). If you would rather not persist
+> the password to disk, provide the `CVDUPDATE_PROXY_*` environment variables at
+> runtime instead. Avoid `cvd update -D` (debug mode) when a proxy is
+> configured: it prints raw HTTP headers, including the `Proxy-Authorization`
+> credentials, to stdout.
+
+> _Note_: the proxy only carries CVD-Update's HTTP traffic. CVD-Update still
+> resolves database versions over DNS first, so the DNS server must remain
+> reachable (see [Using a proxy](#using-a-proxy) for the `--nameservers`
+> workaround on networks that block outbound DNS).
 
 ## Files and directories created by CVD-Update
 
@@ -235,6 +271,27 @@ cvd status daily.cvd
 
 > _Note_: `status` replaces the old `show` command. `show` still works as a deprecated alias and will be removed in a future release. Add `--json` to `status` (and `list`) for machine-readable output.
 
+Check the health and currency of downloaded databases. This compares the local
+version against the version advertised over DNS and reports each database as
+current, behind, unknown, or missing, along with file age and cooldown state.
+
+```bash
+cvd health
+cvd health --json           # machine-readable output
+cvd health --check          # non-zero exit code when not healthy (for scripts)
+```
+
+The `--check` exit codes are `0` (healthy), `1` (warning), and `2` (critical),
+which makes `cvd health --check` convenient for cron jobs and monitoring hooks.
+
+Export database status as Prometheus metrics, either once to stdout or from a
+persistent HTTP server for scraping.
+
+```bash
+cvd metrics                 # print metrics once to stdout
+cvd metrics --serve         # serve metrics at http://127.0.0.1:9090/metrics
+```
+
 Print out the config to see what it looks like.
 
 ```bash
@@ -278,6 +335,9 @@ cvd config show --json         # current configuration
 | `--dbs-directory`, `-d` | Database directory path (your HTTP server's `www` root). |
 | `--cdiffs-rotate` / `--no-cdiffs-rotate` | Rotate (delete) old CDIFF files (default: on). |
 | `--cdiffs-to-keep` | Number of CDIFFs to keep per database when rotating (default `30`). |
+| `--proxy-url` | Proxy URL, e.g. `http://proxy.example.com:8080` (see [Using an authenticated proxy](#using-an-authenticated-proxy)). |
+| `--proxy-user` | Proxy username. |
+| `--proxy-pass` | Proxy password; pass the flag with no value to be prompted. Stored in plaintext (`config.json`, mode `0600`). |
 | `--state-file` | Path to the state file (stores versions, UUID, and per-database metadata). |
 
 ```bash

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -301,13 +301,19 @@ def config():
               help="Number of CDIFF files to keep.")
 @click.option("--state-file", type=click.Path(), default="",
               help="Path to the state file.")
+@click.option("--proxy-url", type=str, default="",
+              help="Proxy URL (e.g. http://proxy.example.com:8080).")
+@click.option("--proxy-user", type=str, default="",
+              help="Proxy username.")
+@click.option("--proxy-pass", type=str, default="", is_flag=False, flag_value="__PROMPT__",
+              help="Proxy password. Use the flag without a value to be prompted.")
 # Deprecated flag names from <= 1.2.0, kept as hidden aliases for backward compatibility.
 @click.option("--nameserver", type=str, default="", hidden=True)
 @click.option("--logdir", type=click.Path(), default="", hidden=True)
 @click.option("--dbdir", type=click.Path(), default="", hidden=True)
 def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, logs_directory,
                logs_rotate, logs_to_keep, dbs_directory, cdiffs_rotate, cdiffs_to_keep,
-               state_file, nameserver, logdir, dbdir):
+               state_file, proxy_url, proxy_user, proxy_pass, nameserver, logdir, dbdir):
     """
     Set configuration options.
 
@@ -350,10 +356,18 @@ def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, log
         and cdiffs_rotate is None
         and cdiffs_to_keep == 0
         and state_file == ""
+        and proxy_url == ""
+        and proxy_user == ""
+        and proxy_pass == ""
     )
     if no_options_set:
         click.echo(ctx.get_help())
         return
+
+    # Prompt for the proxy password when the flag was given without a value.
+    if proxy_pass == "__PROMPT__":
+        proxy_pass = click.prompt("Proxy password", hide_input=True)
+
     CVDUpdate(
         config=config,
         verbose=verbose,
@@ -366,6 +380,9 @@ def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, log
         dbs_directory=dbs_directory,
         cdiffs_rotate=cdiffs_rotate,
         cdiffs_to_keep=cdiffs_to_keep,
+        proxy_url=proxy_url,
+        proxy_user=proxy_user,
+        proxy_pass=proxy_pass,
         state_file=state_file,
     )
 
@@ -379,10 +396,18 @@ def config_show(config: str, verbose: bool, as_json: bool):
     Print out the current configuration.
     """
     m = CVDUpdate(config=config, verbose=verbose)
+
+    # Redact proxy credentials: mask the password and strip any userinfo in the URL.
+    display = dict(m.config)
+    if display.get('proxy_pass'):
+        display['proxy_pass'] = '********'
+    if display.get('proxy_url'):
+        display['proxy_url'] = m._sanitize_proxy_url(display['proxy_url'])
+
     if as_json:
-        print(_json.dumps(m.config, indent=4))
+        print(_json.dumps(display, indent=4))
     else:
-        for key, value in m.config.items():
+        for key, value in display.items():
             cli_key = key.replace('_', '-')
             if value == "" or value is None:
                 print(f"{cli_key}:")
@@ -426,6 +451,208 @@ def clean_all(config: str, verbose: bool):
     """
     m = CVDUpdate(config=config, verbose=verbose)
     m.clean_all()
+
+
+@cli.command("health")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--json", "-j", "output_json", is_flag=True, default=False, help="Output in JSON format.")
+@click.option("--check", is_flag=True, default=False, help="Exit with non-zero status if databases are not healthy.")
+def db_health(config: str, verbose: bool, output_json: bool, check: bool):
+    """
+    Check the health and currency of downloaded databases.
+
+    Reports each database's local and remote version, file age, and version
+    status (current, behind, unknown, or missing). Use --check for scripted
+    health checks that return a non-zero exit code on problems.
+
+    Version status comes from comparing the local version against the version
+    advertised over DNS. When DNS is unavailable the status is reported as
+    unknown rather than behind. The Age column is informational, since some
+    databases such as main.cvd change infrequently and a current mirror can
+    hold an old but correct file. Age thresholds are fixed at 24, 48, and 72
+    hours and are not yet configurable per database.
+    """
+    import datetime
+
+    # Logs to stderr so `health --json` output stays valid JSON.
+    m = CVDUpdate(config=config, verbose=verbose, log_to_stderr=True)
+    status = m.db_status()
+    summary = status['summary']
+
+    if output_json:
+        click.echo(_json.dumps(status, indent=2))
+    else:
+        databases = status['databases']
+        warnings = status['warnings']
+
+        overall = summary['overall_status'].upper()
+        if overall == 'HEALTHY':
+            status_color = Fore.GREEN
+        elif overall == 'WARNING':
+            status_color = Fore.YELLOW
+        else:
+            status_color = Fore.RED
+
+        last_check = datetime.datetime.fromtimestamp(summary['last_check'], tz=datetime.timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
+
+        click.echo("")
+        click.echo("CVD-Update Database Health")
+        click.echo("==========================")
+        click.echo(f"Overall Status: {status_color}{overall}{Style.RESET_ALL}")
+        click.echo(f"Last Check: {last_check}")
+        click.echo("")
+
+        click.echo(f"{'Database':<16} {'Local':<8} {'Remote':<8} {'Age':<10} {'Status':<12} {'Size':<10}")
+        click.echo(f"{'-'*16} {'-'*8} {'-'*8} {'-'*10} {'-'*12} {'-'*10}")
+
+        for db in databases:
+            name = db['name']
+            local_ver = str(db['local_version']) if db['local_version'] is not None else '-'
+            remote_ver = str(db['remote_version']) if db['remote_version'] is not None else '-'
+
+            if db['age_hours'] is None:
+                age_str = '-'
+            elif db['age_hours'] < 1:
+                age_str = f"{int(db['age_hours'] * 60)}m"
+            elif db['age_hours'] < 24:
+                age_str = f"{int(db['age_hours'])}h"
+            else:
+                days = int(db['age_hours'] / 24)
+                hours = int(db['age_hours'] % 24)
+                age_str = f"{days}d {hours}h"
+
+            # Color by version state (the Age column already shows file age).
+            if db['is_missing']:
+                status_str = f"{Fore.RED}MISSING{Style.RESET_ALL}"
+            elif db['version_status'] == 'current':
+                status_str = f"{Fore.GREEN}CURRENT{Style.RESET_ALL}"
+            elif db['version_status'] == 'outdated':
+                status_str = f"{Fore.RED}BEHIND{Style.RESET_ALL}"
+            else:
+                status_str = f"{Fore.YELLOW}UNKNOWN{Style.RESET_ALL}"
+
+            if db['file_size_bytes'] is None:
+                size_str = '-'
+            elif db['file_size_bytes'] < 1024:
+                size_str = f"{db['file_size_bytes']} B"
+            elif db['file_size_bytes'] < 1024 * 1024:
+                size_str = f"{db['file_size_bytes'] / 1024:.1f} KB"
+            else:
+                size_str = f"{db['file_size_bytes'] / (1024 * 1024):.1f} MB"
+
+            # The status column needs extra width to account for color codes.
+            click.echo(f"{name:<16} {local_ver:<8} {remote_ver:<8} {age_str:<10} {status_str:<23} {size_str:<10}")
+
+        click.echo("")
+
+        if warnings:
+            click.echo(f"{Fore.YELLOW}Warnings:{Style.RESET_ALL}")
+            for warning in warnings:
+                click.echo(f"  - {warning}")
+            click.echo("")
+
+        click.echo(f"Summary: {summary['current_count']}/{summary['total_databases']} databases current, {len(warnings)} warnings")
+        click.echo("")
+
+    if check:
+        if summary['overall_status'] == 'healthy':
+            sys.exit(0)
+        elif summary['overall_status'] == 'warning':
+            sys.exit(1)
+        else:  # critical
+            sys.exit(2)
+
+
+@cli.command("metrics")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--serve", "-s", is_flag=True, default=False, help="Start HTTP server for Prometheus scraping.")
+@click.option("--port", "-p", type=int, default=9090, help="Port for metrics server. Default: 9090.")
+@click.option("--bind", "-b", type=str, default="127.0.0.1", help="Address to bind metrics server. Default: 127.0.0.1.")
+@click.option("--cache-ttl", type=int, default=60, help="Seconds to cache status between scrapes in --serve mode. Default: 60.")
+def db_metrics(config: str, verbose: bool, serve: bool, port: int, bind: str, cache_ttl: int):
+    """
+    Output Prometheus metrics for monitoring.
+
+    By default, outputs metrics to stdout for one-shot collection.
+    Use --serve to start a persistent HTTP server for Prometheus scraping.
+    """
+    from cvdupdate.metrics import PrometheusMetrics
+    import http.server
+    import threading
+    import time
+
+    # Logs to stderr so `cvd metrics > file` stays valid Prometheus text.
+    m = CVDUpdate(config=config, verbose=verbose, log_to_stderr=True)
+
+    if serve:
+        # Cache status between scrapes so each request doesn't trigger a live
+        # DNS query.
+        cache_lock = threading.Lock()
+        status_cache = {'status': None, 'time': 0.0}
+
+        def get_cached_status():
+            now = time.time()
+            with cache_lock:
+                if status_cache['status'] is None or (now - status_cache['time']) > cache_ttl:
+                    status_cache['status'] = m.db_status()
+                    status_cache['time'] = now
+                return status_cache['status']
+
+        class MetricsHandler(http.server.BaseHTTPRequestHandler):
+            verbose_mode = verbose
+            timeout = 10  # don't let a slow client stall scrapes
+
+            def do_GET(self):
+                if self.path == '/metrics' or self.path == '/':
+                    try:
+                        status = get_cached_status()
+                        content = PrometheusMetrics(status).generate().encode('utf-8')
+                    except Exception as exc:
+                        # Report 500 rather than dropping the connection.
+                        m.logger.error(f'Failed to generate metrics: {exc}')
+                        self.send_response(500)
+                        self.send_header('Content-Type', 'text/plain; charset=utf-8')
+                        self.end_headers()
+                        self.wfile.write(b'error generating metrics\n')
+                        return
+
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+                    self.send_header('Content-Length', str(len(content)))
+                    self.end_headers()
+                    self.wfile.write(content)
+                elif self.path == '/health':
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'text/plain')
+                    self.end_headers()
+                    self.wfile.write(b'OK')
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def log_message(self, format, *args):
+                if self.verbose_mode:
+                    m.logger.debug(f'{self.address_string()} - {format % args}')
+
+        m.logger.info(f'Starting metrics server on {bind}:{port}')
+        m.logger.info(f'Metrics available at http://{bind}:{port}/metrics')
+
+        # Threaded (a slow client can't block scrapes) with address reuse (a
+        # quick restart won't hit EADDRINUSE).
+        class _MetricsServer(http.server.ThreadingHTTPServer):
+            daemon_threads = True
+
+        with _MetricsServer((bind, port), MetricsHandler) as httpd:
+            try:
+                httpd.serve_forever()
+            except KeyboardInterrupt:
+                m.logger.info('Metrics server stopped')
+    else:
+        status = m.db_status()
+        metrics = PrometheusMetrics(status)
+        click.echo(metrics.generate())
 
 
 @cli.command("serve")

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -401,13 +401,17 @@ class CVDUpdate:
                     raise exc
 
         try:
-            with self.config_path.open('w') as config_file:
-                json.dump(self.config, config_file, indent=4)
-            # Restrict to owner; the config may hold a plaintext proxy password.
+            # The config may hold a plaintext proxy password, so restrict it to
+            # the owner before writing. Open with 0o600 and fchmod the descriptor
+            # so both new files and pre-existing loose ones are tight before the
+            # secret is written.
+            fd = os.open(str(self.config_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
             try:
-                os.chmod(str(self.config_path), 0o600)
-            except OSError:
-                pass  # best-effort (may no-op on Windows)
+                os.fchmod(fd, 0o600)
+            except (OSError, AttributeError):
+                pass  # best-effort (fchmod may be unavailable on Windows)
+            with os.fdopen(fd, 'w') as config_file:
+                json.dump(self.config, config_file, indent=4)
         except Exception as exc:
             print("Failed to create config file!")
             raise exc
@@ -724,15 +728,23 @@ class CVDUpdate:
         import re
         from urllib.parse import urlparse, urlunparse
 
+        # A scheme-less value such as 'user:pass@host:port' makes urlparse read
+        # the username as the scheme and miss the userinfo. Parse a '//'-prefixed
+        # copy in that case, then strip the prefix back off the masked result.
+        had_scheme = '://' in url
+        work = url if had_scheme else f'//{url}'
+
         try:
-            parsed = urlparse(url)
+            parsed = urlparse(work)
             if not parsed.username and not parsed.password:
                 return url
             netloc = f'***:***@{CVDUpdate._proxy_host_port(parsed)}'
-            return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+            masked = urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+            return masked if had_scheme else masked[2:]
         except ValueError:
             # Unparseable URL (e.g. bad port): mask userinfo textually, don't raise.
-            return re.sub(r'(//)[^/@]*@', r'\1***:***@', url)
+            masked = re.sub(r'(^|//)[^/@]*@', r'\1***:***@', work)
+            return masked if had_scheme else masked[2:]
 
     def _get_proxy_configuration(self) -> Optional[dict]:
         '''

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -80,6 +80,10 @@ class CVDUpdate:
         "cdiffs_rotate":  True,
         "cdiffs_to_keep": 30,
 
+        "proxy_url":      "",
+        "proxy_user":     "",
+        "proxy_pass":     "",
+
         # Resolved at load time to "<config dir>/state.json" when not set, so it
         # stays next to the config (and out of the served database directory).
         "state_file":     "",
@@ -136,8 +140,12 @@ class CVDUpdate:
         dbs_directory: str  = "",
         cdiffs_rotate: bool = None,
         cdiffs_to_keep: int = 0,
+        proxy_url: str      = "",
+        proxy_user: str     = "",
+        proxy_pass: str     = "",
         state_file: str     = "",
         verbose: bool       = False,
+        log_to_stderr: bool = False,
     ) -> None:
         """
         CVDUpdate class.
@@ -152,14 +160,20 @@ class CVDUpdate:
             dbs_directory:  Path where databases will be downloaded.
             cdiffs_rotate:  Rotate CDIFF files. Default: True.
             cdiffs_to_keep: Number of CDIFF files to keep. Default: 30.
+            proxy_url:      Proxy URL (e.g. http://proxy.example.com:8080).
+            proxy_user:     Proxy username.
+            proxy_pass:     Proxy password.
             state_file:     Path to the state file.
             verbose:        Enable DEBUG-level logs. Default: False.
+            log_to_stderr:  Send console logs to stderr, keeping stdout for
+                            command output (health --json, metrics). Default: False.
         """
         try:
             self.version = _get_version('cvdupdate')
         except PackageNotFoundError:
             self.version = "0.0"
         self.verbose = verbose
+        self.log_to_stderr = log_to_stderr
         self._read_config(
             config,
             nameservers,
@@ -171,6 +185,9 @@ class CVDUpdate:
             dbs_directory,
             cdiffs_rotate,
             cdiffs_to_keep,
+            proxy_url,
+            proxy_user,
+            proxy_pass,
             state_file)
         self._init_logging()
 
@@ -188,7 +205,10 @@ class CVDUpdate:
             def filter(self, record: logging.LogRecord) -> bool:
                 return record.levelno < stderr_level
 
-        stdout_handler = logging.StreamHandler(sys.stdout)
+        # Route logs to stderr for commands that print machine-readable output on
+        # stdout (health --json, metrics); otherwise sub-WARNING logs go to stdout.
+        stdout_stream = sys.stderr if self.log_to_stderr else sys.stdout
+        stdout_handler = logging.StreamHandler(stdout_stream)
         stdout_handler.addFilter(FilterNotStdErr())
 
         handlers: list = [stderr_handler, stdout_handler]
@@ -232,6 +252,9 @@ class CVDUpdate:
                      dbs_directory: str,
                      cdiffs_rotate: Optional[bool],
                      cdiffs_to_keep: int,
+                     proxy_url: str,
+                     proxy_user: str,
+                     proxy_pass: str,
                      state_file: str) -> None:
         """
         Read in the config file.
@@ -340,6 +363,15 @@ class CVDUpdate:
         if cdiffs_to_keep != 0:
             self.config["cdiffs_to_keep"] = cdiffs_to_keep
             need_save = True
+        if proxy_url != "":
+            self.config["proxy_url"] = proxy_url
+            need_save = True
+        if proxy_user != "":
+            self.config["proxy_user"] = proxy_user
+            need_save = True
+        if proxy_pass != "":
+            self.config["proxy_pass"] = proxy_pass
+            need_save = True
         if state_file != "":
             self.config["state_file"] = state_file
             need_save = True
@@ -371,6 +403,11 @@ class CVDUpdate:
         try:
             with self.config_path.open('w') as config_file:
                 json.dump(self.config, config_file, indent=4)
+            # Restrict to owner; the config may hold a plaintext proxy password.
+            try:
+                os.chmod(str(self.config_path), 0o600)
+            except OSError:
+                pass  # best-effort (may no-op on Windows)
         except Exception as exc:
             print("Failed to create config file!")
             raise exc
@@ -656,6 +693,311 @@ class CVDUpdate:
 
         return ""
 
+    @staticmethod
+    def _proxy_host_port(parsed) -> str:
+        '''
+        Format host[:port] from a parsed URL, handling IPv6 brackets and a
+        possibly-invalid port (parsed.port raises ValueError on bad input).
+        '''
+        host = parsed.hostname or ''
+        if ':' in host:
+            # re-bracket IPv6 literals (urlparse strips the brackets)
+            host = f'[{host}]'
+        try:
+            port = parsed.port
+        except ValueError:
+            port = None
+        if port:
+            host = f'{host}:{port}'
+        return host
+
+    @staticmethod
+    def _sanitize_proxy_url(url: str) -> str:
+        '''
+        Return the proxy URL with any embedded userinfo masked, so that
+        credentials are never written to logs or printed by `config show`.
+        Never raises: a malformed URL falls back to textual userinfo masking.
+        '''
+        if not url:
+            return url
+
+        import re
+        from urllib.parse import urlparse, urlunparse
+
+        try:
+            parsed = urlparse(url)
+            if not parsed.username and not parsed.password:
+                return url
+            netloc = f'***:***@{CVDUpdate._proxy_host_port(parsed)}'
+            return urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+        except ValueError:
+            # Unparseable URL (e.g. bad port): mask userinfo textually, don't raise.
+            return re.sub(r'(//)[^/@]*@', r'\1***:***@', url)
+
+    def _get_proxy_configuration(self) -> Optional[dict]:
+        '''
+        Get proxy configuration from environment variables or config file.
+        Environment variables take precedence over config file settings.
+
+        If proxy credentials are configured, they are embedded in the proxy
+        URL so that the requests library sends the Proxy-Authorization header.
+
+        Returns:
+            dict: Proxy configuration for requests, or None if not configured.
+        '''
+        from urllib.parse import urlparse, urlunparse, quote
+
+        proxy_url = os.environ.get('CVDUPDATE_PROXY_URL')
+
+        if not proxy_url:
+            proxy_url = self.config.get('proxy_url')
+
+        if not proxy_url:
+            return None
+
+        # Assume http:// when no scheme; otherwise 'host:port' is mis-parsed
+        # (urlparse reads the host as the scheme).
+        if '://' not in proxy_url:
+            self.logger.debug(f"Proxy URL '{proxy_url}' has no scheme; assuming http://")
+            proxy_url = f'http://{proxy_url}'
+
+        proxy_user = os.environ.get('CVDUPDATE_PROXY_USER')
+        proxy_pass = os.environ.get('CVDUPDATE_PROXY_PASS')
+
+        if not proxy_user:
+            proxy_user = self.config.get('proxy_user')
+        if not proxy_pass:
+            proxy_pass = self.config.get('proxy_pass')
+
+        if proxy_user and proxy_pass:
+            parsed = urlparse(proxy_url)
+            if not parsed.username:
+                netloc = f'{quote(proxy_user, safe="")}:{quote(proxy_pass, safe="")}@{self._proxy_host_port(parsed)}'
+                proxy_url = urlunparse((parsed.scheme, netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
+            self.logger.info(f'Using authenticated proxy: {self._sanitize_proxy_url(proxy_url)}')
+        else:
+            self.logger.info(f'Using proxy: {self._sanitize_proxy_url(proxy_url)}')
+
+        return {
+            'http': proxy_url,
+            'https': proxy_url,
+        }
+
+    def _calculate_age_status(self, last_modified: float) -> tuple:
+        '''
+        Calculate age status based on last modification time.
+
+        Args:
+            last_modified: Unix timestamp of last modification
+
+        Returns:
+            tuple: (age_hours, age_status)
+        '''
+        if last_modified == 0:
+            return (None, 'missing')
+
+        age_seconds = time.time() - last_modified
+        age_hours = age_seconds / 3600
+
+        if age_hours < 24:
+            return (age_hours, 'current')
+        elif age_hours < 48:
+            return (age_hours, 'recent')
+        elif age_hours < 72:
+            return (age_hours, 'stale')
+        else:
+            return (age_hours, 'outdated')
+
+    def db_status(self) -> dict:
+        '''
+        Get status of all databases.
+
+        Returns:
+            dict: Status report containing:
+                - summary: Overall health summary
+                - databases: Per-database status details
+                - warnings: List of issues requiring attention
+        '''
+        dbs = self._index_local_databases()
+        warnings = []
+        databases = []
+
+        # Try to get remote versions via DNS
+        dns_available = False
+        self.dns_version_tokens = []
+        for _attempt in range(self.config.get('max_retries', 3)):
+            if self._query_dns_txt_entry():
+                dns_available = True
+                break
+            time.sleep(0.1)
+
+        if not dns_available:
+            warnings.append('DNS query failed, unable to verify remote versions')
+
+        current_count = 0
+        stale_count = 0
+        outdated_count = 0
+        unknown_count = 0
+        missing_count = 0
+        cooldown_count = 0
+
+        for db_name in dbs:
+            db_info = dbs[db_name]
+            db_path = self.dbs_directory / db_name
+
+            # Build the row in a try/except so one malformed entry (e.g. a bad
+            # 'retry after') yields an error row instead of crashing the report.
+            # Shared tallies are only touched below, after this succeeds.
+            try:
+                is_missing = not db_path.exists()
+
+                local_version = db_info.get('local version', 0) if db_name.endswith('.cvd') else None
+
+                remote_version = None
+                if dns_available and db_name.endswith('.cvd') and db_info.get('DNS field', 0) > 0:
+                    try:
+                        remote_version = int(self.dns_version_tokens[db_info['DNS field']])
+                    except (IndexError, ValueError):
+                        pass
+
+                # 'unknown' (couldn't verify remote, e.g. DNS down) stays distinct
+                # from 'outdated'.
+                is_current = False
+                if local_version is not None and remote_version is not None:
+                    if local_version >= remote_version:
+                        version_status = 'current'
+                        is_current = True
+                    else:
+                        version_status = 'outdated'
+                else:
+                    version_status = 'unknown'
+
+                # Coerce a missing/corrupt timestamp to 0.
+                last_modified = db_info.get('last modified', 0) or 0
+                if not isinstance(last_modified, (int, float)):
+                    last_modified = 0
+                age_hours, age_status = self._calculate_age_status(last_modified)
+
+                # Coerce a corrupt 'retry after' too.
+                on_cooldown = False
+                cooldown_until = None
+                cooldown_str = None
+                retry_after = db_info.get('retry after', 0) or 0
+                if not isinstance(retry_after, (int, float)):
+                    retry_after = 0
+                if retry_after > time.time():
+                    on_cooldown = True
+                    cooldown_until = retry_after
+                    cooldown_str = datetime.datetime.fromtimestamp(retry_after).strftime('%Y-%m-%d %H:%M:%S')
+
+                # Get file size
+                file_size_bytes = None
+                if not is_missing:
+                    try:
+                        file_size_bytes = db_path.stat().st_size
+                    except OSError:
+                        pass
+
+                cdiff_count = len(db_info.get('CDIFFs', []) or [])
+
+                age_seconds = None
+                if last_modified > 0:
+                    age_seconds = time.time() - last_modified
+            except Exception as exc:
+                self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
+                self.logger.error(f"Failed to read status for {db_name}: {exc}")
+                missing_count += 1
+                warnings.append(f'Database {db_name} could not be read: {exc}')
+                databases.append({
+                    'name': db_name,
+                    'local_version': None,
+                    'remote_version': None,
+                    'is_current': False,
+                    'version_status': 'error',
+                    'is_missing': True,
+                    'last_modified': 0,
+                    'age_hours': None,
+                    'age_seconds': None,
+                    'age_status': 'missing',
+                    'on_cooldown': False,
+                    'cooldown_until': None,
+                    'cdiff_count': 0,
+                    'file_size_bytes': None,
+                })
+                continue
+
+            # Commit shared tallies only after a clean computation.
+            if is_missing:
+                missing_count += 1
+                warnings.append(f'Database {db_name} is missing from disk')
+
+            if version_status == 'outdated':
+                warnings.append(f'Database {db_name} is behind: local v{local_version} vs remote v{remote_version}')
+
+            # Age alone doesn't mark a db unhealthy: main.cvd changes rarely, so a
+            # current mirror can hold an old but correct file.
+            if not is_missing:
+                if version_status == 'current':
+                    current_count += 1
+                elif version_status == 'outdated':
+                    outdated_count += 1
+                else:
+                    unknown_count += 1
+
+            # Only flag age staleness when the database is not confirmed current.
+            if age_status in ('stale', 'outdated') and version_status != 'current':
+                stale_count += 1
+                if age_hours is not None:
+                    warnings.append(f'Database {db_name} is {int(age_hours)} hours old and may be stale')
+
+            if on_cooldown:
+                cooldown_count += 1
+                warnings.append(f'Database {db_name} is on cooldown until {cooldown_str}')
+
+            databases.append({
+                'name': db_name,
+                'local_version': local_version,
+                'remote_version': remote_version,
+                'is_current': is_current,
+                'version_status': version_status,
+                'is_missing': is_missing,
+                'last_modified': last_modified,
+                'age_hours': age_hours,
+                'age_seconds': age_seconds,
+                'age_status': age_status,
+                'on_cooldown': on_cooldown,
+                'cooldown_until': cooldown_until,
+                'cdiff_count': cdiff_count,
+                'file_size_bytes': file_size_bytes,
+            })
+
+        # Overall status from actionable conditions only. A DNS failure adds a
+        # warning but does not change status, so a DNS blip won't fail --check
+        # when the on-disk databases are current.
+        total_databases = len(dbs)
+        if missing_count > 0:
+            overall_status = 'critical'
+        elif outdated_count > 0 or cooldown_count > 0 or stale_count > 0:
+            overall_status = 'warning'
+        else:
+            overall_status = 'healthy'
+
+        return {
+            'summary': {
+                'total_databases': total_databases,
+                'current_count': current_count,
+                'stale_count': stale_count,
+                'outdated_count': outdated_count,
+                'unknown_count': unknown_count,
+                'missing_count': missing_count,
+                'cooldown_count': cooldown_count,
+                'overall_status': overall_status,
+                'last_check': time.time(),
+            },
+            'databases': databases,
+            'warnings': warnings,
+        }
+
     def _query_cvd_version_dns(self, db: str) -> int:
         '''
         This is a faux query.
@@ -709,6 +1051,7 @@ class CVDUpdate:
 
         ims = datetime.datetime.fromtimestamp(self.state['dbs'][db]['last modified'], tz=datetime.timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
+        proxies = self._get_proxy_configuration()
         retry = 0
         response = None
         while retry < self.config['max_retries']:
@@ -716,7 +1059,7 @@ class CVDUpdate:
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'Range': 'bytes=0-95',
                 'If-Modified-Since': ims,
-            })
+            }, proxies=proxies)
 
             if ((response.status_code == 200 or response.status_code == 206) and
                 ('content-length' in response.headers) and
@@ -781,13 +1124,14 @@ class CVDUpdate:
         '''
         ims: str = datetime.datetime.fromtimestamp(last_modified, tz=datetime.timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
+        proxies = self._get_proxy_configuration()
         retry = 0
         response = None
         while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'If-Modified-Since': ims,
-            })
+            }, proxies=proxies)
 
             if ((response.status_code == 200 or response.status_code == 206) and
                 ('content-length' in response.headers) and
@@ -887,12 +1231,13 @@ class CVDUpdate:
         base_url = db_url.rsplit('/', 1)[0]
         url = f"{base_url}/{file}"
 
+        proxies = self._get_proxy_configuration()
         retry = 0
         response = None
         while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
-            })
+            }, proxies=proxies)
 
             if ((response.status_code == 200 or response.status_code == 206) and
                 ('content-length' in response.headers) and
@@ -997,13 +1342,14 @@ class CVDUpdate:
         base_url = file_url.rsplit('/', 1)[0]
         url = f"{base_url}/{sign_file}"
 
+        proxies = self._get_proxy_configuration()
         retry = 0
         response = None
         while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'If-Modified-Since': ims,
-            })
+            }, proxies=proxies)
 
             if ((response.status_code == 200 or response.status_code == 206) and
                 ('content-length' in response.headers) and
@@ -1182,7 +1528,7 @@ class CVDUpdate:
                 current_version_str = _get_version(name)
                 current_version = version.parse(current_version_str)
 
-                response = requests.get(f"https://pypi.org/pypi/{name}/json")  # Get package info
+                response = requests.get(f"https://pypi.org/pypi/{name}/json", proxies=self._get_proxy_configuration())  # Get package info
                 response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
                 latest_version_str = response.json()["info"]["version"]
                 latest_version = version.parse(latest_version_str)

--- a/cvdupdate/metrics.py
+++ b/cvdupdate/metrics.py
@@ -151,4 +151,3 @@ class PrometheusMetrics:
         lines.append(f'cvdupdate_last_check_timestamp {int(last_check)}')
 
         return '\n'.join(lines) + '\n'
-

--- a/cvdupdate/metrics.py
+++ b/cvdupdate/metrics.py
@@ -1,0 +1,154 @@
+"""
+Prometheus metrics generation for CVD-Update.
+
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+from typing import Dict, Any, List
+
+
+METRIC_PREFIX = 'cvdupdate'
+
+
+class PrometheusMetrics:
+    """Generate Prometheus-format metrics from CVD-Update status."""
+
+    def __init__(self, status: Dict[str, Any]):
+        """
+        Initialize metrics generator with status data.
+
+        Args:
+            status: Status dict from CVDUpdate.db_status()
+        """
+        self.status = status
+        self.timestamp = int(time.time())  # Unix seconds; fallback for last_check
+
+    @staticmethod
+    def _escape_label_value(value: str) -> str:
+        '''
+        Escape a label value per the Prometheus text exposition format:
+        backslash, double quote, and newline must be escaped.
+        '''
+        return (
+            str(value)
+            .replace('\\', '\\\\')
+            .replace('"', '\\"')
+            .replace('\n', '\\n')
+        )
+
+    def generate(self) -> str:
+        """
+        Generate Prometheus metrics text.
+
+        Returns:
+            str: Prometheus exposition format text
+        """
+        lines: List[str] = []
+
+        # Add metadata comments
+        lines.append('# HELP cvdupdate_database_version Local version of ClamAV database')
+        lines.append('# TYPE cvdupdate_database_version gauge')
+
+        lines.append('# HELP cvdupdate_database_remote_version Remote version available')
+        lines.append('# TYPE cvdupdate_database_remote_version gauge')
+
+        lines.append('# HELP cvdupdate_database_age_seconds Age of database in seconds')
+        lines.append('# TYPE cvdupdate_database_age_seconds gauge')
+
+        lines.append('# HELP cvdupdate_database_current Database is current (1) or outdated (0)')
+        lines.append('# TYPE cvdupdate_database_current gauge')
+
+        lines.append('# HELP cvdupdate_database_missing Database is missing (1) or present (0)')
+        lines.append('# TYPE cvdupdate_database_missing gauge')
+
+        lines.append('# HELP cvdupdate_database_cooldown Database is on cooldown (1) or not (0)')
+        lines.append('# TYPE cvdupdate_database_cooldown gauge')
+
+        lines.append('# HELP cvdupdate_database_size_bytes Size of database file in bytes')
+        lines.append('# TYPE cvdupdate_database_size_bytes gauge')
+
+        lines.append('# HELP cvdupdate_database_cdiff_count Number of CDIFF patch files')
+        lines.append('# TYPE cvdupdate_database_cdiff_count gauge')
+
+        lines.append('# HELP cvdupdate_databases_total Total number of configured databases')
+        lines.append('# TYPE cvdupdate_databases_total gauge')
+
+        lines.append('# HELP cvdupdate_databases_current Number of current databases')
+        lines.append('# TYPE cvdupdate_databases_current gauge')
+
+        lines.append('# HELP cvdupdate_databases_stale Number of stale databases')
+        lines.append('# TYPE cvdupdate_databases_stale gauge')
+
+        lines.append('# HELP cvdupdate_databases_missing Number of missing databases')
+        lines.append('# TYPE cvdupdate_databases_missing gauge')
+
+        lines.append('# HELP cvdupdate_health_status Overall health (0=critical, 1=warning, 2=healthy)')
+        lines.append('# TYPE cvdupdate_health_status gauge')
+
+        lines.append('# HELP cvdupdate_last_check_timestamp Unix timestamp of last status check')
+        lines.append('# TYPE cvdupdate_last_check_timestamp gauge')
+
+        # Per-database metrics
+        for db in self.status.get('databases', []):
+            name = self._escape_label_value(db['name'])
+            labels = f'database="{name}"'
+
+            if db.get('local_version') is not None:
+                lines.append(f'cvdupdate_database_version{{{labels}}} {db["local_version"]}')
+
+            if db.get('remote_version') is not None:
+                lines.append(f'cvdupdate_database_remote_version{{{labels}}} {db["remote_version"]}')
+
+            if db.get('age_seconds') is not None:
+                lines.append(f'cvdupdate_database_age_seconds{{{labels}}} {db["age_seconds"]:.0f}')
+
+            # Skip the gauge when unverified, so 'unknown' isn't reported as 0.
+            if db.get('version_status', 'unknown') != 'unknown':
+                current = 1 if db.get('is_current') else 0
+                lines.append(f'cvdupdate_database_current{{{labels}}} {current}')
+
+            missing = 1 if db.get('is_missing') else 0
+            lines.append(f'cvdupdate_database_missing{{{labels}}} {missing}')
+
+            cooldown = 1 if db.get('on_cooldown') else 0
+            lines.append(f'cvdupdate_database_cooldown{{{labels}}} {cooldown}')
+
+            if db.get('file_size_bytes') is not None:
+                lines.append(f'cvdupdate_database_size_bytes{{{labels}}} {db["file_size_bytes"]}')
+
+            if db.get('cdiff_count') is not None:
+                lines.append(f'cvdupdate_database_cdiff_count{{{labels}}} {db["cdiff_count"]}')
+
+        # Summary metrics
+        summary = self.status.get('summary', {})
+
+        lines.append(f'cvdupdate_databases_total {summary.get("total_databases", 0)}')
+        lines.append(f'cvdupdate_databases_current {summary.get("current_count", 0)}')
+        lines.append(f'cvdupdate_databases_stale {summary.get("stale_count", 0)}')
+        lines.append(f'cvdupdate_databases_missing {summary.get("missing_count", 0)}')
+
+        # Map status to numeric value
+        status_map = {'critical': 0, 'warning': 1, 'healthy': 2}
+        health_value = status_map.get(summary.get('overall_status', 'critical'), 0)
+        lines.append(f'cvdupdate_health_status {health_value}')
+
+        # Report when the status was collected, not when it was rendered: in
+        # --serve mode a cached status is re-rendered on every scrape.
+        last_check = summary.get('last_check', self.timestamp)
+        lines.append(f'cvdupdate_last_check_timestamp {int(last_check)}')
+
+        return '\n'.join(lines) + '\n'
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import re
 import threading
 import http.client
 from http.server import HTTPServer
+from unittest import mock
 
 from click.testing import CliRunner
 
@@ -266,3 +267,239 @@ def test_serve_handler_hides_dotfiles_and_dotdirs(tmp_path, monkeypatch):
         httpd.shutdown()
         httpd.server_close()
         server_thread.join(timeout=5)
+
+
+# --- config set: proxy options ---------------------------------------------
+
+def test_config_set_persists_proxy_url(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(
+        cli, ['config', 'set', '--config', cfg, '--proxy-url', 'http://proxy.example.com:8080'])
+    assert result.exit_code == 0, result.output
+    assert _load_config(tmp_path)['proxy_url'] == 'http://proxy.example.com:8080'
+
+
+def test_config_set_persists_proxy_user_and_pass(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(
+        cli, ['config', 'set', '--config', cfg, '--proxy-user', 'alice', '--proxy-pass', 'secret'])
+    assert result.exit_code == 0, result.output
+    data = _load_config(tmp_path)
+    assert data['proxy_user'] == 'alice'
+    assert data['proxy_pass'] == 'secret'
+
+
+# --- health ----------------------------------------------------------------
+
+def test_health_runs(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch('cvdupdate.cvdupdate.CVDUpdate._query_dns_txt_entry', return_value=False):
+        result = CliRunner().invoke(cli, ['health', '--config', cfg])
+    assert result.exit_code == 0, result.output
+    assert 'Database Health' in result.output
+
+
+def test_health_check_exits_critical_when_all_missing(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch('cvdupdate.cvdupdate.CVDUpdate._query_dns_txt_entry', return_value=False):
+        result = CliRunner().invoke(cli, ['health', '--config', cfg, '--check'])
+    assert result.exit_code == 2
+
+
+def test_health_json_with_check_does_not_crash(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch('cvdupdate.cvdupdate.CVDUpdate._query_dns_txt_entry', return_value=False):
+        result = CliRunner().invoke(cli, ['health', '--config', cfg, '--json', '--check'])
+    assert result.exit_code in (0, 1, 2)
+    payload = json.loads(result.output)
+    assert 'summary' in payload
+
+
+# --- metrics ---------------------------------------------------------------
+
+def test_metrics_runs(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch('cvdupdate.cvdupdate.CVDUpdate._query_dns_txt_entry', return_value=False):
+        result = CliRunner().invoke(cli, ['metrics', '--config', cfg])
+    assert result.exit_code == 0, result.output
+    assert 'cvdupdate_databases_total' in result.output
+
+
+# --- machine-readable stdout must not be contaminated by log lines ----------
+
+_SENTINEL = 'NAMESERVER_SENTINEL_LINE'
+
+
+def _dns_fail_but_log(self):
+    """Stand-in for _query_dns_txt_entry that emits a log line, then fails.
+
+    Reproduces the real INFO log the DNS lookup writes, so we can prove it lands
+    on stderr rather than in the JSON / metrics payload on stdout.
+    """
+    self.logger.info(_SENTINEL)
+    return False
+
+
+def _write_config_state(tmp_path, dbs):
+    """Write an isolated config.json + state.json with the given state 'dbs'."""
+    db_dir = tmp_path / 'database'
+    db_dir.mkdir(exist_ok=True)
+    config = {
+        'nameservers': '', 'max_retries': 3, 'logs_enabled': False,
+        'logs_directory': str(tmp_path / 'logs'), 'logs_rotate': True, 'logs_to_keep': 30,
+        'dbs_directory': str(db_dir), 'cdiffs_rotate': True, 'cdiffs_to_keep': 30,
+        'proxy_url': '', 'proxy_user': '', 'proxy_pass': '',
+        'state_file': str(tmp_path / 'state.json'),
+    }
+    state = {'dbs': dbs, 'uuid': 'test-uuid'}
+    (tmp_path / 'config.json').write_text(json.dumps(config))
+    (tmp_path / 'state.json').write_text(json.dumps(state))
+    return str(tmp_path / 'config.json'), db_dir
+
+
+def test_health_json_stdout_is_clean_despite_logs(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, side_effect=_dns_fail_but_log):
+        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--json'])
+    assert result.exit_code == 0, result.output
+    # stdout must be valid JSON, uncontaminated by the log line ...
+    payload = json.loads(result.output)
+    assert 'summary' in payload
+    assert _SENTINEL not in result.output
+    # ... and the log line must have gone to stderr instead.
+    assert _SENTINEL in result.stderr
+
+
+def test_metrics_stdout_is_clean_despite_logs(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, side_effect=_dns_fail_but_log):
+        result = CliRunner(mix_stderr=False).invoke(cli, ['metrics', '--config', cfg])
+    assert result.exit_code == 0, result.output
+    non_empty = [l for l in result.output.splitlines() if l.strip()]
+    # Every stdout line is a HELP/TYPE comment or a metric sample, never a log.
+    assert non_empty
+    assert all(l.startswith('#') or l.startswith('cvdupdate_') for l in non_empty)
+    assert _SENTINEL in result.stderr
+
+
+# --- health --check must not false-page on a transient DNS failure ----------
+
+def test_health_check_healthy_when_current_but_dns_down(revert_homedir, tmp_path):
+    import time
+    cfg, db_dir = _write_config_state(tmp_path, {
+        'test.cud': {
+            'url': 'http://example/test.cud', 'retry after': 0,
+            'last modified': time.time(), 'last checked': 0, 'DNS field': 0,
+            'local version': 0, 'CDIFFs': [],
+        }
+    })
+    (db_dir / 'test.cud').write_text('present')
+    with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, return_value=False):
+        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--check'])
+    # DBs present on disk + DNS unavailable => healthy, exit 0 (not a false page).
+    assert result.exit_code == 0, result.output
+
+
+# --- health/metrics must not crash on a malformed state entry ---------------
+
+def test_health_survives_corrupt_state_entry(revert_homedir, tmp_path):
+    cfg, db_dir = _write_config_state(tmp_path, {
+        'daily.cud': {
+            'url': 'http://example/daily.cud', 'retry after': None,
+            'last modified': None, 'last checked': 0, 'DNS field': 0,
+            'local version': 0, 'CDIFFs': None,
+        }
+    })
+    (db_dir / 'daily.cud').write_text('present')
+    with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, return_value=False):
+        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--json'])
+    # A malformed 'retry after'/'last modified'/'CDIFFs' must not crash the
+    # report; valid JSON on stdout proves db_status produced a verdict.
+    payload = json.loads(result.output)
+    assert 'summary' in payload
+
+
+# --- metrics --serve endpoints and address reuse ----------------------------
+
+def test_metrics_server_class_allows_address_reuse():
+    """The switch away from raw TCPServer fixes EADDRINUSE on quick restart."""
+    from http.server import ThreadingHTTPServer
+    assert ThreadingHTTPServer.allow_reuse_address  # truthy (stdlib uses 1)
+
+
+def test_metrics_server_serves_endpoints_and_rebinds(revert_homedir, tmp_path):
+    import os
+    import sys
+    import time
+    import socket
+    import subprocess
+    import http.client
+
+    cfg = _init_config(tmp_path)
+
+    # Reserve then release an ephemeral port for the child to bind.
+    probe = socket.socket()
+    probe.bind(('127.0.0.1', 0))
+    port = probe.getsockname()[1]
+    probe.close()
+
+    env = dict(os.environ)
+    env['PYTHONPATH'] = os.getcwd() + os.pathsep + env.get('PYTHONPATH', '')
+
+    def _start():
+        return subprocess.Popen(
+            [sys.executable, '-m', 'cvdupdate', 'metrics', '--serve',
+             '--port', str(port), '--bind', '127.0.0.1', '--config', cfg],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+
+    def _wait_up():
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                conn = http.client.HTTPConnection('127.0.0.1', port, timeout=1)
+                conn.request('GET', '/health')
+                resp = conn.getresponse()
+                resp.read()
+                conn.close()
+                if resp.status == 200:
+                    return True
+            except OSError:
+                time.sleep(0.15)
+        return False
+
+    proc = _start()
+    try:
+        assert _wait_up(), 'metrics server did not start'
+        conn = http.client.HTTPConnection('127.0.0.1', port, timeout=2)
+        conn.request('GET', '/metrics')
+        resp = conn.getresponse()
+        body = resp.read().decode()
+        assert resp.status == 200
+        assert 'cvdupdate_databases_total' in body
+        conn.request('GET', '/does-not-exist')
+        resp = conn.getresponse()
+        resp.read()
+        assert resp.status == 404
+        conn.close()
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    # Immediately rebind the same port: must not fail with EADDRINUSE.
+    proc2 = _start()
+    try:
+        assert _wait_up(), 'metrics server failed to rebind the port (EADDRINUSE?)'
+    finally:
+        proc2.terminate()
+        proc2.wait(timeout=5)
+
+
+# --- a new option must not break a sibling command --------------------------
+
+def test_proxy_cert_option_is_removed(revert_homedir, tmp_path):
+    """The removed --proxy-cert options must not resurface (they once aborted
+    config set entirely via click.Path(exists=True) on an empty default)."""
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['config', 'set', '--config', cfg, '--proxy-cert', '/x'])
+    assert result.exit_code != 0
+    assert 'no such option' in result.output.lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,19 @@ def _all_output(result):
     return text
 
 
+def _stderr_runner():
+    """A CliRunner that keeps stdout and stderr separate across Click versions."""
+    try:
+        return CliRunner(mix_stderr=False)  # Click < 8.2
+    except TypeError:
+        return CliRunner()                  # Click >= 8.2 always separates streams
+
+
+def _stdout(result):
+    """Stdout only; on Click >= 8.2 result.output may include stderr."""
+    return getattr(result, 'stdout', result.output)
+
+
 # --- status / list ---------------------------------------------------------
 
 def test_list_prints_only_names(revert_homedir, tmp_path):
@@ -360,12 +373,13 @@ def _write_config_state(tmp_path, dbs):
 def test_health_json_stdout_is_clean_despite_logs(revert_homedir, tmp_path):
     cfg = _init_config(tmp_path)
     with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, side_effect=_dns_fail_but_log):
-        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--json'])
+        result = _stderr_runner().invoke(cli, ['health', '--config', cfg, '--json'])
     assert result.exit_code == 0, result.output
     # stdout must be valid JSON, uncontaminated by the log line ...
-    payload = json.loads(result.output)
+    out = _stdout(result)
+    payload = json.loads(out)
     assert 'summary' in payload
-    assert _SENTINEL not in result.output
+    assert _SENTINEL not in out
     # ... and the log line must have gone to stderr instead.
     assert _SENTINEL in result.stderr
 
@@ -373,9 +387,9 @@ def test_health_json_stdout_is_clean_despite_logs(revert_homedir, tmp_path):
 def test_metrics_stdout_is_clean_despite_logs(revert_homedir, tmp_path):
     cfg = _init_config(tmp_path)
     with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, side_effect=_dns_fail_but_log):
-        result = CliRunner(mix_stderr=False).invoke(cli, ['metrics', '--config', cfg])
+        result = _stderr_runner().invoke(cli, ['metrics', '--config', cfg])
     assert result.exit_code == 0, result.output
-    non_empty = [l for l in result.output.splitlines() if l.strip()]
+    non_empty = [l for l in _stdout(result).splitlines() if l.strip()]
     # Every stdout line is a HELP/TYPE comment or a metric sample, never a log.
     assert non_empty
     assert all(l.startswith('#') or l.startswith('cvdupdate_') for l in non_empty)
@@ -395,7 +409,7 @@ def test_health_check_healthy_when_current_but_dns_down(revert_homedir, tmp_path
     })
     (db_dir / 'test.cud').write_text('present')
     with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, return_value=False):
-        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--check'])
+        result = _stderr_runner().invoke(cli, ['health', '--config', cfg, '--check'])
     # DBs present on disk + DNS unavailable => healthy, exit 0 (not a false page).
     assert result.exit_code == 0, result.output
 
@@ -412,10 +426,10 @@ def test_health_survives_corrupt_state_entry(revert_homedir, tmp_path):
     })
     (db_dir / 'daily.cud').write_text('present')
     with mock.patch.object(CVDUpdate, '_query_dns_txt_entry', autospec=True, return_value=False):
-        result = CliRunner(mix_stderr=False).invoke(cli, ['health', '--config', cfg, '--json'])
+        result = _stderr_runner().invoke(cli, ['health', '--config', cfg, '--json'])
     # A malformed 'retry after'/'last modified'/'CDIFFs' must not crash the
     # report; valid JSON on stdout proves db_status produced a verdict.
-    payload = json.loads(result.output)
+    payload = json.loads(_stdout(result))
     assert 'summary' in payload
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,399 @@
+"""
+Tests for Prometheus metrics generation.
+
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import re
+from unittest import mock
+
+import pytest
+
+from tests.fixtures.revert import revert_homedir
+from cvdupdate.cvdupdate import CVDUpdate
+from cvdupdate.metrics import PrometheusMetrics
+
+
+class TestPrometheusMetricsGenerate:
+    """Tests for PrometheusMetrics.generate method."""
+
+    def test_generates_valid_prometheus_format(self):
+        """Test that output is valid Prometheus exposition format."""
+        status = {
+            'summary': {
+                'total_databases': 3,
+                'current_count': 2,
+                'stale_count': 1,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'warning',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': 'main.cvd',
+                    'version_status': 'current',
+                    'local_version': 62,
+                    'remote_version': 62,
+                    'is_current': True,
+                    'is_missing': False,
+                    'age_seconds': 3600,
+                    'on_cooldown': False,
+                    'file_size_bytes': 157286400,
+                    'cdiff_count': 5,
+                },
+            ],
+            'warnings': [],
+        }
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        # Should end with newline
+        assert output.endswith('\n')
+
+        # Should contain HELP and TYPE comments
+        assert '# HELP' in output
+        assert '# TYPE' in output
+
+        # Should contain metric names
+        assert 'cvdupdate_database_version' in output
+        assert 'cvdupdate_databases_total' in output
+        assert 'cvdupdate_health_status' in output
+
+    def test_includes_all_expected_metrics(self):
+        """Test that all expected metrics are present."""
+        status = {
+            'summary': {
+                'total_databases': 1,
+                'current_count': 1,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'healthy',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': 'test.cvd',
+                    'version_status': 'current',
+                    'local_version': 100,
+                    'remote_version': 100,
+                    'is_current': True,
+                    'is_missing': False,
+                    'age_seconds': 1800,
+                    'on_cooldown': False,
+                    'file_size_bytes': 1024,
+                    'cdiff_count': 2,
+                },
+            ],
+            'warnings': [],
+        }
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        expected_metrics = [
+            'cvdupdate_database_version',
+            'cvdupdate_database_remote_version',
+            'cvdupdate_database_age_seconds',
+            'cvdupdate_database_current',
+            'cvdupdate_database_missing',
+            'cvdupdate_database_cooldown',
+            'cvdupdate_database_size_bytes',
+            'cvdupdate_database_cdiff_count',
+            'cvdupdate_databases_total',
+            'cvdupdate_databases_current',
+            'cvdupdate_databases_stale',
+            'cvdupdate_databases_missing',
+            'cvdupdate_health_status',
+            'cvdupdate_last_check_timestamp',
+        ]
+
+        for metric in expected_metrics:
+            assert metric in output, f'Missing metric: {metric}'
+
+    def test_labels_are_correctly_formatted(self):
+        """Test that labels use correct quoting."""
+        status = {
+            'summary': {
+                'total_databases': 1,
+                'current_count': 1,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'healthy',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': 'daily.cvd',
+                    'version_status': 'current',
+                    'local_version': 27456,
+                    'remote_version': 27456,
+                    'is_current': True,
+                    'is_missing': False,
+                    'age_seconds': 3600,
+                    'on_cooldown': False,
+                    'file_size_bytes': 60817408,
+                    'cdiff_count': 10,
+                },
+            ],
+            'warnings': [],
+        }
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        # Labels should use double quotes
+        assert 'database="daily.cvd"' in output
+
+    def test_health_status_maps_correctly(self):
+        """Test that health status maps to correct numeric values."""
+        test_cases = [
+            ('healthy', 2),
+            ('warning', 1),
+            ('critical', 0),
+        ]
+
+        for status_str, expected_value in test_cases:
+            status = {
+                'summary': {
+                    'total_databases': 1,
+                    'current_count': 1,
+                    'stale_count': 0,
+                    'missing_count': 0,
+                    'cooldown_count': 0,
+                    'overall_status': status_str,
+                    'last_check': 1704556800.0,
+                },
+                'databases': [],
+                'warnings': [],
+            }
+
+            metrics = PrometheusMetrics(status)
+            output = metrics.generate()
+
+            assert f'cvdupdate_health_status {expected_value}' in output
+
+    def test_handles_none_values_gracefully(self):
+        """Test that None values are handled correctly."""
+        status = {
+            'summary': {
+                'total_databases': 1,
+                'current_count': 0,
+                'stale_count': 0,
+                'missing_count': 1,
+                'cooldown_count': 0,
+                'overall_status': 'critical',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': 'missing.cvd',
+                    'local_version': None,
+                    'remote_version': None,
+                    'is_current': False,
+                    'is_missing': True,
+                    'age_seconds': None,
+                    'on_cooldown': False,
+                    'file_size_bytes': None,
+                    'cdiff_count': 0,
+                },
+            ],
+            'warnings': [],
+        }
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        # Should not contain 'None' as text
+        assert 'None' not in output
+
+        # Should still have the missing metric
+        assert 'cvdupdate_database_missing{database="missing.cvd"} 1' in output
+
+
+class TestMetricsIntegration:
+    """Integration tests for metrics with CVDUpdate."""
+
+    def test_metrics_from_cvdupdate_status(self, revert_homedir):
+        """Test generating metrics from actual CVDUpdate status."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        # Should be non-empty
+        assert len(output) > 0
+
+        # The missing gauge is emitted once per database, so it tracks count.
+        db_count = output.count('cvdupdate_database_missing{')
+        assert db_count == len(status['databases'])
+
+    def test_metrics_output_matches_status_values(self, revert_homedir):
+        """Test that metrics output matches status dict values."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        metrics = PrometheusMetrics(status)
+        output = metrics.generate()
+
+        # Check summary metrics match
+        total = status['summary']['total_databases']
+        assert f'cvdupdate_databases_total {total}' in output
+
+        current = status['summary']['current_count']
+        assert f'cvdupdate_databases_current {current}' in output
+
+        stale = status['summary']['stale_count']
+        assert f'cvdupdate_databases_stale {stale}' in output
+
+        missing = status['summary']['missing_count']
+        assert f'cvdupdate_databases_missing {missing}' in output
+
+
+class TestMetricsLabelEscaping:
+    """Tests for Prometheus label value escaping."""
+
+    def _status_with_name(self, name):
+        return {
+            'summary': {
+                'total_databases': 1,
+                'current_count': 1,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'healthy',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': name,
+                    'version_status': 'current',
+                    'local_version': 1,
+                    'remote_version': 1,
+                    'is_current': True,
+                    'is_missing': False,
+                    'age_seconds': 1,
+                    'on_cooldown': False,
+                    'file_size_bytes': 1,
+                    'cdiff_count': 0,
+                },
+            ],
+            'warnings': [],
+        }
+
+    def test_escapes_backslash_quote_and_newline(self):
+        """Label values must escape backslash, double quote, and newline."""
+        output = PrometheusMetrics(self._status_with_name('a\\b"c\nd.cvd')).generate()
+        assert 'database="a\\\\b\\"c\\nd.cvd"' in output
+        # A raw newline must never appear inside a label value.
+        for line in output.splitlines():
+            assert not (line.startswith('cvdupdate_database') and line.endswith('database="a'))
+
+    def test_plain_name_is_unchanged(self):
+        """A name without special characters is emitted verbatim."""
+        output = PrometheusMetrics(self._status_with_name('daily.cvd')).generate()
+        assert 'database="daily.cvd"' in output
+
+
+class TestMetricsTimestampUnit:
+    """Tests for the last-check timestamp unit."""
+
+    def test_timestamp_is_seconds_not_milliseconds(self):
+        """The timestamp must be Unix seconds (10 digits), not milliseconds."""
+        status = {
+            'summary': {
+                'total_databases': 0,
+                'current_count': 0,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'healthy',
+                'last_check': 1704556800.0,
+            },
+            'databases': [],
+            'warnings': [],
+        }
+        output = PrometheusMetrics(status).generate()
+        line = next(l for l in output.splitlines() if l.startswith('cvdupdate_last_check_timestamp '))
+        value = int(line.split()[1])
+        # Seconds are ~10 digits through the year 2286; milliseconds are ~13.
+        assert 10 ** 9 <= value < 10 ** 11
+
+    def test_timestamp_reflects_summary_last_check(self):
+        """Must report when the status was collected, not when it was rendered.
+
+        In --serve mode a cached status is re-rendered on every scrape, so using
+        the render time would make staleness alerts impossible to trip.
+        """
+        status = {
+            'summary': {
+                'total_databases': 0,
+                'current_count': 0,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'healthy',
+                'last_check': 1704556800.0,
+            },
+            'databases': [],
+            'warnings': [],
+        }
+        output = PrometheusMetrics(status).generate()
+        line = next(l for l in output.splitlines() if l.startswith('cvdupdate_last_check_timestamp '))
+        assert int(line.split()[1]) == 1704556800
+
+
+class TestMetricsUnknownVersion:
+    """Tests that an unverified version is not reported as outdated."""
+
+    def test_current_gauge_omitted_when_unknown(self):
+        """The current gauge is skipped when the version could not be verified."""
+        status = {
+            'summary': {
+                'total_databases': 1,
+                'current_count': 0,
+                'stale_count': 0,
+                'missing_count': 0,
+                'cooldown_count': 0,
+                'overall_status': 'warning',
+                'last_check': 1704556800.0,
+            },
+            'databases': [
+                {
+                    'name': 'main.cvd',
+                    'version_status': 'unknown',
+                    'local_version': 62,
+                    'remote_version': None,
+                    'is_current': False,
+                    'is_missing': False,
+                    'age_seconds': 1,
+                    'on_cooldown': False,
+                    'file_size_bytes': 1,
+                    'cdiff_count': 0,
+                },
+            ],
+            'warnings': [],
+        }
+        output = PrometheusMetrics(status).generate()
+        assert 'cvdupdate_database_current{database="main.cvd"}' not in output
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -396,4 +396,3 @@ class TestMetricsUnknownVersion:
         }
         output = PrometheusMetrics(status).generate()
         assert 'cvdupdate_database_current{database="main.cvd"}' not in output
-

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -143,6 +143,17 @@ class TestPasswordMasking:
         assert 'supersecret' not in result.output
         assert '***:***@proxy.example.com:8080' in result.output
 
+    def test_config_show_masks_scheme_less_embedded_credentials(self, revert_homedir):
+        """A scheme-less proxy_url with userinfo must be masked in config show."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'user:supersecret@proxy.example.com:8080'
+        c._save_config()
+
+        result = CliRunner().invoke(cli, ['config', 'show', '--config', str(c.config_path)])
+        assert result.exit_code == 0
+        assert 'supersecret' not in result.output
+        assert '***:***@proxy.example.com:8080' in result.output
+
 
 class TestSanitizeProxyUrl:
     """Tests for the _sanitize_proxy_url helper."""
@@ -168,6 +179,17 @@ class TestSanitizeProxyUrl:
         url = 'http://user:secret@proxy.example.com:notaport'
         sanitized = CVDUpdate._sanitize_proxy_url(url)
         assert 'secret' not in sanitized
+
+    def test_masks_scheme_less_userinfo(self, revert_homedir):
+        # urlparse reads 'alice' as the scheme unless we normalize first.
+        url = 'alice:secret@proxy.example.com:8080'
+        sanitized = CVDUpdate._sanitize_proxy_url(url)
+        assert 'secret' not in sanitized
+        assert sanitized == '***:***@proxy.example.com:8080'
+
+    def test_leaves_scheme_less_url_without_userinfo_unchanged(self, revert_homedir):
+        url = 'proxy.example.com:8080'
+        assert CVDUpdate._sanitize_proxy_url(url) == url
 
 
 class TestProxyUrlHardening:
@@ -251,6 +273,22 @@ class TestConfigFilePermissions:
         mode = stat.S_IMODE(os.stat(cfg).st_mode)
         assert mode == 0o600
 
+    @pytest.mark.skipif(os.name != 'posix', reason='POSIX file modes only')
+    def test_pre_existing_loose_config_is_tightened(self, revert_homedir, tmp_path):
+        import stat
+        cfg = tmp_path / 'config.json'
+        cfg.write_text('{}')
+        os.chmod(str(cfg), 0o644)
+        c = CVDUpdate(
+            config=str(cfg),
+            state_file=str(tmp_path / 'state.json'),
+            dbs_directory=str(tmp_path / 'db'),
+        )
+        c.config['proxy_pass'] = 'secret'
+        c._save_config()
+        mode = stat.S_IMODE(os.stat(cfg).st_mode)
+        assert mode == 0o600
+
 
 class TestProxyLogging:
     """Tests that proxy credentials are never written to the logs."""
@@ -279,4 +317,3 @@ class TestProxyLogging:
         # Nothing logged may contain the secret.
         assert all('supersecret' not in msg for msg in messages)
         assert any('***:***@proxy.example.com:8080' in msg for msg in messages)
-

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -1,0 +1,282 @@
+"""
+Tests for proxy authentication support.
+
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import os
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from tests.fixtures.revert import revert_homedir
+from cvdupdate.cvdupdate import CVDUpdate
+from cvdupdate.__main__ import cli
+
+
+class TestGetProxyConfiguration:
+    """Tests for _get_proxy_configuration method."""
+
+    def test_returns_none_when_not_configured(self, revert_homedir):
+        """Test that None is returned when no proxy is configured."""
+        c = CVDUpdate()
+        result = c._get_proxy_configuration()
+        assert result is None
+
+    def test_returns_proxy_from_config(self, revert_homedir):
+        """Test that proxy URL is returned from config."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+        result = c._get_proxy_configuration()
+        assert result == {
+            'http': 'http://proxy.example.com:8080',
+            'https': 'http://proxy.example.com:8080',
+        }
+
+    def test_env_var_takes_precedence(self, revert_homedir):
+        """Test that environment variable takes precedence over config."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://config-proxy.example.com:8080'
+
+        with mock.patch.dict(os.environ, {'CVDUPDATE_PROXY_URL': 'http://env-proxy.example.com:3128'}):
+            result = c._get_proxy_configuration()
+            assert result == {
+                'http': 'http://env-proxy.example.com:3128',
+                'https': 'http://env-proxy.example.com:3128',
+            }
+
+    def test_embeds_credentials_in_proxy_url(self, revert_homedir):
+        """Test that user/pass are embedded in the proxy URL for Proxy-Authorization."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+        c.config['proxy_user'] = 'testuser'
+        c.config['proxy_pass'] = 'testpass'
+        result = c._get_proxy_configuration()
+        assert result == {
+            'http': 'http://testuser:testpass@proxy.example.com:8080',
+            'https': 'http://testuser:testpass@proxy.example.com:8080',
+        }
+
+    def test_url_encodes_special_chars_in_credentials(self, revert_homedir):
+        """Test that special characters in credentials are URL-encoded."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+        c.config['proxy_user'] = 'user@domain'
+        c.config['proxy_pass'] = 'p@ss:word/123'
+        result = c._get_proxy_configuration()
+        assert 'user%40domain' in result['http']
+        assert 'p%40ss%3Aword%2F123' in result['http']
+        assert '@proxy.example.com:8080' in result['http']
+
+    def test_does_not_double_embed_credentials(self, revert_homedir):
+        """Test that credentials already in the URL are not duplicated."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://existinguser:existingpass@proxy.example.com:8080'
+        c.config['proxy_user'] = 'newuser'
+        c.config['proxy_pass'] = 'newpass'
+        result = c._get_proxy_configuration()
+        assert 'existinguser:existingpass@' in result['http']
+        assert 'newuser' not in result['http']
+
+    def test_env_credentials_take_precedence(self, revert_homedir):
+        """Test that env var credentials take precedence over config."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+        c.config['proxy_user'] = 'config_user'
+        c.config['proxy_pass'] = 'config_pass'
+
+        with mock.patch.dict(os.environ, {
+            'CVDUPDATE_PROXY_USER': 'env_user',
+            'CVDUPDATE_PROXY_PASS': 'env_pass',
+        }):
+            result = c._get_proxy_configuration()
+            assert 'env_user:env_pass@' in result['http']
+
+    def test_no_credentials_without_both_user_and_pass(self, revert_homedir):
+        """Test that credentials are not embedded when only user or only pass is set."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+        c.config['proxy_user'] = 'testuser'
+        result = c._get_proxy_configuration()
+        assert 'testuser' not in result['http']
+        assert result == {
+            'http': 'http://proxy.example.com:8080',
+            'https': 'http://proxy.example.com:8080',
+        }
+
+
+class TestPasswordMasking:
+    """Tests for credential masking in the 'config show' command."""
+
+    def test_config_show_masks_password(self, revert_homedir):
+        """Test that password is masked in config show output."""
+        c = CVDUpdate()
+        c.config['proxy_pass'] = 'supersecret'
+        c._save_config()
+
+        result = CliRunner().invoke(cli, ['config', 'show', '--config', str(c.config_path)])
+        assert result.exit_code == 0
+        assert 'supersecret' not in result.output
+        assert '********' in result.output
+
+    def test_config_show_masks_credentials_in_proxy_url(self, revert_homedir):
+        """Credentials embedded directly in proxy_url must be masked too."""
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://user:supersecret@proxy.example.com:8080'
+        c._save_config()
+
+        result = CliRunner().invoke(cli, ['config', 'show', '--config', str(c.config_path)])
+        assert result.exit_code == 0
+        assert 'supersecret' not in result.output
+        assert '***:***@proxy.example.com:8080' in result.output
+
+
+class TestSanitizeProxyUrl:
+    """Tests for the _sanitize_proxy_url helper."""
+
+    def test_masks_userinfo(self, revert_homedir):
+        url = 'http://user:secret@proxy.example.com:8080/path'
+        sanitized = CVDUpdate._sanitize_proxy_url(url)
+        assert 'secret' not in sanitized
+        assert sanitized == 'http://***:***@proxy.example.com:8080/path'
+
+    def test_leaves_url_without_userinfo_unchanged(self, revert_homedir):
+        url = 'http://proxy.example.com:8080'
+        assert CVDUpdate._sanitize_proxy_url(url) == url
+
+    def test_masks_ipv6_userinfo(self, revert_homedir):
+        url = 'http://user:secret@[::1]:3128'
+        sanitized = CVDUpdate._sanitize_proxy_url(url)
+        assert 'secret' not in sanitized
+        assert sanitized == 'http://***:***@[::1]:3128'
+
+    def test_does_not_crash_on_invalid_port(self, revert_homedir):
+        # urlparse validates the port lazily; a malformed one must not raise.
+        url = 'http://user:secret@proxy.example.com:notaport'
+        sanitized = CVDUpdate._sanitize_proxy_url(url)
+        assert 'secret' not in sanitized
+
+
+class TestProxyUrlHardening:
+    """Malformed / IPv6 / scheme-less proxy URLs must not crash sibling commands."""
+
+    def test_ipv6_with_credentials_composes_valid_url(self, revert_homedir):
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://[::1]:3128'
+        c.config['proxy_user'] = 'alice'
+        c.config['proxy_pass'] = 'pw'
+        result = c._get_proxy_configuration()
+        # IPv6 host must stay bracketed so requests/urllib3 accepts it.
+        assert result['http'] == 'http://alice:pw@[::1]:3128'
+
+    def test_scheme_less_url_gets_http_prefix_and_keeps_port(self, revert_homedir):
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'proxy.example.com:8080'
+        c.config['proxy_user'] = 'alice'
+        c.config['proxy_pass'] = 'pw'
+        result = c._get_proxy_configuration()
+        assert result['http'] == 'http://alice:pw@proxy.example.com:8080'
+
+    def test_malformed_port_does_not_crash(self, revert_homedir):
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://user:pw@proxy.example.com:notaport'
+        # Must return a dict (or None) rather than raising ValueError.
+        assert c._get_proxy_configuration() is not None
+
+    def test_config_show_survives_malformed_proxy_url(self, revert_homedir):
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://user:secret@proxy.example.com:notaport'
+        c._save_config()
+        result = CliRunner().invoke(cli, ['config', 'show', '--config', str(c.config_path)])
+        assert result.exit_code == 0, result.output
+        assert 'secret' not in result.output
+
+
+class TestProxiesReachRequests:
+    """The composed proxies dict must actually be handed to requests.get."""
+
+    def test_proxies_passed_to_requests_get(self, revert_homedir, monkeypatch):
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://proxy.example.com:8080'
+
+        captured = {}
+
+        class _Resp:
+            status_code = 200
+            headers = {}
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'info': {'version': '0.0'}}
+
+        def _fake_get(url, **kwargs):
+            captured['proxies'] = kwargs.get('proxies')
+            return _Resp()
+
+        monkeypatch.setattr('cvdupdate.cvdupdate.requests.get', _fake_get)
+        c.pypi_update_check()
+        assert captured['proxies'] == {
+            'http': 'http://proxy.example.com:8080',
+            'https': 'http://proxy.example.com:8080',
+        }
+
+
+class TestConfigFilePermissions:
+    """The config may hold a plaintext password, so it must not be world-readable."""
+
+    @pytest.mark.skipif(os.name != 'posix', reason='POSIX file modes only')
+    def test_config_file_is_owner_only_after_saving_password(self, revert_homedir, tmp_path):
+        import stat
+        cfg = tmp_path / 'config.json'
+        c = CVDUpdate(
+            config=str(cfg),
+            state_file=str(tmp_path / 'state.json'),
+            dbs_directory=str(tmp_path / 'db'),
+        )
+        c.config['proxy_pass'] = 'secret'
+        c._save_config()
+        mode = stat.S_IMODE(os.stat(cfg).st_mode)
+        assert mode == 0o600
+
+
+class TestProxyLogging:
+    """Tests that proxy credentials are never written to the logs."""
+
+    def test_log_does_not_leak_credentials_in_proxy_url(self, revert_homedir):
+        import logging
+
+        c = CVDUpdate()
+        c.config['proxy_url'] = 'http://user:supersecret@proxy.example.com:8080'
+
+        messages = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                messages.append(record.getMessage())
+
+        handler = _Capture()
+        c.logger.addHandler(handler)
+        try:
+            result = c._get_proxy_configuration()
+        finally:
+            c.logger.removeHandler(handler)
+
+        # The returned proxy URL still carries the real credentials for use.
+        assert 'supersecret' in result['http']
+        # Nothing logged may contain the secret.
+        assert all('supersecret' not in msg for msg in messages)
+        assert any('***:***@proxy.example.com:8080' in msg for msg in messages)
+

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,298 @@
+"""
+Tests for database status command.
+
+Copyright (C) 2021-2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import time
+from unittest import mock
+
+import pytest
+
+from tests.fixtures.revert import revert_homedir
+from cvdupdate.cvdupdate import CVDUpdate
+
+
+class TestCalculateAgeStatus:
+    """Tests for _calculate_age_status method."""
+
+    def test_returns_missing_for_zero_timestamp(self, revert_homedir):
+        """Test that missing status is returned for zero timestamp."""
+        c = CVDUpdate()
+        age_hours, age_status = c._calculate_age_status(0)
+        assert age_hours is None
+        assert age_status == 'missing'
+
+    def test_returns_current_for_recent_files(self, revert_homedir):
+        """Test that current status is returned for files less than 24 hours old."""
+        c = CVDUpdate()
+        # 12 hours ago
+        last_modified = time.time() - (12 * 3600)
+        age_hours, age_status = c._calculate_age_status(last_modified)
+        assert 11 < age_hours < 13
+        assert age_status == 'current'
+
+    def test_returns_recent_for_24_to_48_hours(self, revert_homedir):
+        """Test that recent status is returned for files 24-48 hours old."""
+        c = CVDUpdate()
+        # 36 hours ago
+        last_modified = time.time() - (36 * 3600)
+        age_hours, age_status = c._calculate_age_status(last_modified)
+        assert 35 < age_hours < 37
+        assert age_status == 'recent'
+
+    def test_returns_stale_for_48_to_72_hours(self, revert_homedir):
+        """Test that stale status is returned for files 48-72 hours old."""
+        c = CVDUpdate()
+        # 60 hours ago
+        last_modified = time.time() - (60 * 3600)
+        age_hours, age_status = c._calculate_age_status(last_modified)
+        assert 59 < age_hours < 61
+        assert age_status == 'stale'
+
+    def test_returns_outdated_for_over_72_hours(self, revert_homedir):
+        """Test that outdated status is returned for files over 72 hours old."""
+        c = CVDUpdate()
+        # 96 hours ago
+        last_modified = time.time() - (96 * 3600)
+        age_hours, age_status = c._calculate_age_status(last_modified)
+        assert 95 < age_hours < 97
+        assert age_status == 'outdated'
+
+
+class TestDbStatus:
+    """Tests for db_status method."""
+
+    def test_returns_correct_structure(self, revert_homedir):
+        """Test that db_status returns the expected structure."""
+        c = CVDUpdate()
+
+        # Mock DNS query to avoid network calls
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        assert 'summary' in status
+        assert 'databases' in status
+        assert 'warnings' in status
+
+        # Check summary structure
+        summary = status['summary']
+        assert 'total_databases' in summary
+        assert 'current_count' in summary
+        assert 'stale_count' in summary
+        assert 'missing_count' in summary
+        assert 'cooldown_count' in summary
+        assert 'overall_status' in summary
+        assert 'last_check' in summary
+
+        # Check databases is a list
+        assert isinstance(status['databases'], list)
+
+        # Check warnings is a list
+        assert isinstance(status['warnings'], list)
+
+    def test_detects_missing_databases(self, revert_homedir):
+        """Test that missing databases are detected."""
+        c = CVDUpdate()
+
+        # Databases don't exist since we haven't downloaded them
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        # All databases should be reported as missing
+        assert status['summary']['missing_count'] == len(status['databases'])
+
+    def test_json_output_is_valid(self, revert_homedir):
+        """Test that status can be serialized to valid JSON."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        # Should not raise
+        json_str = json.dumps(status)
+        assert json_str
+
+        # Should be valid JSON
+        parsed = json.loads(json_str)
+        assert parsed == status
+
+    def test_overall_status_values(self, revert_homedir):
+        """Test that overall_status has valid values."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        assert status['summary']['overall_status'] in ['healthy', 'warning', 'critical']
+
+    def test_dns_failure_warning(self, revert_homedir):
+        """Test that DNS failure adds a warning."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        dns_warnings = [w for w in status['warnings'] if 'DNS' in w]
+        assert len(dns_warnings) > 0
+
+
+class TestDbStatusDatabaseFields:
+    """Tests for individual database fields in db_status."""
+
+    def test_database_has_required_fields(self, revert_homedir):
+        """Test that each database entry has required fields."""
+        c = CVDUpdate()
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        required_fields = [
+            'name',
+            'local_version',
+            'remote_version',
+            'is_current',
+            'version_status',
+            'is_missing',
+            'last_modified',
+            'age_hours',
+            'age_seconds',
+            'age_status',
+            'on_cooldown',
+            'cooldown_until',
+            'cdiff_count',
+            'file_size_bytes',
+        ]
+
+        for db in status['databases']:
+            for field in required_fields:
+                assert field in db, f"Missing field: {field}"
+
+    def test_cooldown_detection(self, revert_homedir):
+        """Test that cooldown is correctly detected."""
+        c = CVDUpdate()
+
+        # Set a database on cooldown
+        c.state['dbs']['main.cvd']['retry after'] = time.time() + 3600
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        main_db = next(db for db in status['databases'] if db['name'] == 'main.cvd')
+        assert main_db['on_cooldown'] is True
+        assert main_db['cooldown_until'] is not None
+
+        # Check warning was added
+        cooldown_warnings = [w for w in status['warnings'] if 'cooldown' in w]
+        assert len(cooldown_warnings) > 0
+
+
+class TestDbStatusVersionState:
+    """Tests that version state distinguishes unknown, current, and outdated."""
+
+    def _single_main_db(self, c, local_version, last_modified):
+        c.dbs_directory.mkdir(parents=True, exist_ok=True)
+        (c.dbs_directory / 'main.cvd').write_bytes(b'x')
+        c.state['dbs'] = {
+            'main.cvd': {
+                'url': 'https://database.clamav.net/main.cvd',
+                'retry after': 0,
+                'last modified': last_modified,
+                'last checked': 0,
+                'DNS field': 1,
+                'local version': local_version,
+                'CDIFFs': [],
+            }
+        }
+
+    def test_unknown_when_dns_unavailable(self, revert_homedir):
+        """A present database with no remote version is unknown, not outdated."""
+        c = CVDUpdate()
+        self._single_main_db(c, local_version=62, last_modified=time.time())
+
+        with mock.patch.object(c, '_query_dns_txt_entry', return_value=False):
+            status = c.db_status()
+
+        main_db = next(db for db in status['databases'] if db['name'] == 'main.cvd')
+        assert main_db['version_status'] == 'unknown'
+        assert main_db['is_current'] is False
+        assert status['summary']['unknown_count'] == 1
+        assert status['summary']['outdated_count'] == 0
+
+    def test_outdated_when_local_behind_remote(self, revert_homedir):
+        """A database behind the advertised version is outdated and warns."""
+        c = CVDUpdate()
+        self._single_main_db(c, local_version=60, last_modified=time.time())
+
+        def fake_dns():
+            c.dns_version_tokens = ['0', '62']
+            return True
+
+        with mock.patch.object(c, '_query_dns_txt_entry', side_effect=fake_dns):
+            status = c.db_status()
+
+        main_db = next(db for db in status['databases'] if db['name'] == 'main.cvd')
+        assert main_db['version_status'] == 'outdated'
+        assert status['summary']['outdated_count'] == 1
+        assert status['summary']['overall_status'] == 'warning'
+        assert any('behind' in w for w in status['warnings'])
+
+    def test_current_with_old_file_is_healthy(self, revert_homedir):
+        """A current database is healthy even when its file is old."""
+        c = CVDUpdate()
+        self._single_main_db(c, local_version=62, last_modified=time.time() - (200 * 3600))
+
+        def fake_dns():
+            c.dns_version_tokens = ['0', '62']
+            return True
+
+        with mock.patch.object(c, '_query_dns_txt_entry', side_effect=fake_dns):
+            status = c.db_status()
+
+        main_db = next(db for db in status['databases'] if db['name'] == 'main.cvd')
+        assert main_db['version_status'] == 'current'
+        assert status['summary']['stale_count'] == 0
+        assert status['summary']['overall_status'] == 'healthy'
+
+    def test_fresh_non_cvd_database_is_healthy(self, revert_homedir):
+        """A freshly downloaded non-CVD database has no version, so it is
+        reported as unknown but must not flag the mirror as unhealthy."""
+        c = CVDUpdate()
+        c.dbs_directory.mkdir(parents=True, exist_ok=True)
+        (c.dbs_directory / 'custom.ndb').write_bytes(b'x')
+        c.state['dbs'] = {
+            'custom.ndb': {
+                'url': 'https://example.com/custom.ndb',
+                'retry after': 0,
+                'last modified': time.time(),
+                'last checked': 0,
+                'DNS field': 0,
+                'local version': 0,
+                'CDIFFs': [],
+            }
+        }
+
+        def fake_dns():
+            c.dns_version_tokens = ['0', '62']
+            return True
+
+        with mock.patch.object(c, '_query_dns_txt_entry', side_effect=fake_dns):
+            status = c.db_status()
+
+        custom = next(db for db in status['databases'] if db['name'] == 'custom.ndb')
+        assert custom['version_status'] == 'unknown'
+        assert status['summary']['overall_status'] == 'healthy'
+

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -295,4 +295,3 @@ class TestDbStatusVersionState:
         custom = next(db for db in status['databases'] if db['name'] == 'custom.ndb')
         assert custom['version_status'] == 'unknown'
         assert status['summary']['overall_status'] == 'healthy'
-


### PR DESCRIPTION
- Add authenticated proxy support via environment variables or config
- Send proxy credentials as a Basic Proxy-Authorization header (Digest and NTLM are not supported)
- Add 'cvd status' command for database health checks
- Add 'cvd metrics' command for Prometheus monitoring
- Bump version to 1.3.0

Closes #7 and #9. All existing tests pass, plus new unit tests covering the proxy, status, and metrics paths, including Click-level CLI tests.