### PR TITLE
Prevent commands from being duplicated in crontab

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -18,6 +18,8 @@ if [ $# -eq 0 ]; then
     set -e
 
     echo "Adding crontab entry"
+    cron_start_marker="# cvdupdate managed cron start"
+    cron_end_marker="# cvdupdate managed cron end"
     if [ "${USER_ID}" -ne "0" ]; then
         timed_command="${CRON:-"30 */4 * * *"} /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
         reboot_command="@reboot /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
@@ -25,15 +27,25 @@ if [ $# -eq 0 ]; then
         timed_command="${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
         reboot_command="@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
     fi
-
-    new_crontab="$(crontab -l || echo "")"
-    if ! echo "$new_crontab" | grep -qF "$timed_command"; then
-        new_crontab="$new_crontab\n$timed_command"
-    fi
-    if ! echo "$new_crontab" | grep -qF "$reboot_command"; then
-        new_crontab="$new_crontab\n$reboot_command"
-    fi
-    echo -e "$new_crontab" | crontab -
+    unmanaged_crontab="$(
+        crontab -l 2>/dev/null \
+            | awk -v start="$cron_start_marker" -v end="$cron_end_marker" '
+                $0 == start { managed = 1; next }
+                $0 == end { managed = 0; next }
+                managed { next }
+                /\/usr\/local\/bin\/cvdupdate update >\/proc\/1\/fd\/1 2>\/proc\/1\/fd\/2$/ { next }
+                { print }
+            ' || true
+    )"
+    {
+        if [ -n "$unmanaged_crontab" ]; then
+            printf '%s\n' "$unmanaged_crontab"
+        fi
+        printf '%s\n' "$cron_start_marker"
+        printf '%s\n' "$timed_command"
+        printf '%s\n' "$reboot_command"
+        printf '%s\n' "$cron_end_marker"
+    } | crontab -
 
     cron -f
 else

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -19,18 +19,22 @@ if [ $# -eq 0 ]; then
 
     echo "Adding crontab entry"
     if [ "${USER_ID}" -ne "0" ]; then
-        crontab -l | {
-            cat
-            echo "${CRON:-"30 */4 * * *"} /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-            echo "@reboot /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-        } | crontab -
+        timed_command="${CRON:-"30 */4 * * *"} /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+        reboot_command="@reboot /usr/sbin/gosu cvdupdate /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
     else
-        crontab -l | {
-            cat
-            echo "${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-            echo "@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
-        } | crontab -
+        timed_command="${CRON:-"30 */4 * * *"} /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
+        reboot_command="@reboot /usr/local/bin/cvdupdate update >/proc/1/fd/1 2>/proc/1/fd/2"
     fi
+
+    new_crontab="$(crontab -l || echo "")"
+    if ! echo "$new_crontab" | grep -qF "$timed_command"; then
+        new_crontab="$new_crontab\n$timed_command"
+    fi
+    if ! echo "$new_crontab" | grep -qF "$reboot_command"; then
+        new_crontab="$new_crontab\n$reboot_command"
+    fi
+    echo -e "$new_crontab" | crontab -
+
     cron -f
 else
     if [ "${USER_ID}" -ne "0" ]; then


### PR DESCRIPTION
`scripts/docker-entrypoint.sh` will currently duplicate commands in the `crontab` if the cvdupdate container is stopped and then restarted.

This fixes it by checking if the commands already exist in the `crontab` using `grep -qF` and only adding them if they don't already exist.

Resolves #89.
