### PR TITLE
Improve usability

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,59 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Version 1.3.0
+
+- ➕ Added a `cvd status` command (alias `s`) that reports the status of all
+  databases, or of a single database when given a name. Pass `--json` for
+  machine-readable output. The `cvd list` command (alias `ls`) now prints just
+  the database names — one per line, or a JSON array with `--json` — to make
+  its output easy to parse.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- ➕ Added a `--override` flag to `cvd add` so the remote URL of an existing
+  database can be updated without removing and re-adding it.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- ➕ The `cvd config set` command now exposes every configuration option, with
+  names normalized to a consistent style (e.g. `--logs-directory`,
+  `--dbs-directory`, `--nameservers`, `--logs-enabled`, `--max-retries`,
+  `--state-file`). Short aliases are now available for the common commands:
+  `status (s)`, `update (u)`, `list (ls)`, `remove (rm)`, `config (cf)`, and
+  `clean (cl)`.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- 🌌 File logging is now opt-in. New installations no longer write log files
+  unless logging is enabled with `cvd config set --logs-enabled`, which keeps
+  output quiet for container and systemd usage. Existing v1.2 and older
+  configurations that specified a log directory are migrated with logging
+  left enabled.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- ➕ `cvd serve` now accepts port `0`, which lets the OS assign a random free
+  port; the chosen port is logged after binding. The default port is unchanged
+  (`8000`).
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- 🛡 The `cvd serve` test mirror now hides dot-prefixed files and directories,
+  so hidden files (such as a `.state.json` state file) aren't exposed when
+  serving the database directory.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
+- 👇 Deprecated the `show` command in favor of `status`; the `--logdir`,
+  `--dbdir`, and `--nameserver` options of `config set` in favor of
+  `--logs-directory`, `--dbs-directory`, and `--nameservers`; and the
+  `CVDUPDATE_NAMESERVER` environment variable in favor of
+  `CVDUPDATE_NAMESERVERS`. The deprecated names continue to work, with a
+  warning, and will be removed in a future release.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/88)
+
 ## Version 1.2.0
 
 - ➕ Support for downloading CVD and CDIFF digital signatures.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cvd --help
 (optional) You may wish to customize where the databases are stored:
 
 ```bash
-cvd config set --dbdir <your www path>
+cvd config set --dbs-directory <your www path>
 ```
 
 Run this to download the latest database and associated CDIFF patch files:
@@ -90,6 +90,8 @@ Run this to serve up the database directory on `http://localhost:8000` so you ca
 ```bash
 cvd serve
 ```
+
+> _Tip_: `cvd serve` listens on port `8000` by default. Pass a port number to change it (e.g. `cvd serve 9000`), or pass `0` to have the OS pick a random available port (the chosen port is logged after binding).
 
 > _Disclaimer_: The `cvd serve` feature is not intended for production use, just for testing. You probably want to use a more robust HTTP server for production work.
 
@@ -113,33 +115,23 @@ Run `cvd update` as often as you need.  Maybe put it in a `cron` job.
 
 ### Cron Example
 
-Cron is a popular choice to automate frequent tasks on Linux / Unix systems.
+On Linux/Unix you can schedule updates with cron. Edit the crontab of the user CVD-Update should run as:
 
-1. Open a terminal running as the user which you want CVD-Update to run under, do the following:
+```bash
+crontab -e
+```
 
-   ```bash
-   crontab -e
-   ```
+Add a line such as:
 
-2. Press `i` to insert new text, and add this line:
+```bash
+30 */4 * * * /home/username/.local/bin/cvd update >/dev/null 2>&1
+```
 
-   ```bash
-   30 */4 * * * /bin/sh -c "~/.local/bin/cvd update &> /dev/null"
-   ```
+This runs `cvd update` at minute 30 of every 4th hour. Use the full path to `cvd` (run `which cvd` to find it), since cron does not load your shell's `PATH`.
 
-   Or instead of `~/`, you can do this, replacing `username` with your user name:
+Like FreshClam, CVD-Update first does a DNS version check and only downloads when something changed, so running it a few times a day is fine.
 
-   ```bash
-   30 */4 * * * /bin/sh -c "/home/username/.local/bin/cvd update &> /dev/null"
-   ```
-
-3. Press <Escape>, then type `:wq` and press <Enter> to write the file to disk and quit.
-
-**About these settings**:
-
-I selected `30 */4 * * *` to run at minute 30 past every 4th hour. CVD-Update uses a DNS check to do version checks before it attempts to download any files, just like FreshClam. Running CVD-Update more than once a day should not be an issue.
-
-CVD-Update will write logs to the `~/.cvdupdate/logs` directory, which is why I directed `stdout` and `stderr` to `/dev/null` instead of a log file. You can use the `cvd config set` command to customize the log directory if you like, or redirect `stdout` and `stderr` to a log file if you prefer everything in one log instead of separate daily logs.
+The example discards output with `>/dev/null 2>&1`; drop that to send output to cron's mail, or redirect to a file to keep it. For separate daily log files in `~/.cvdupdate/logs`, enable file logging with `cvd config set --logs-enabled` (use `--logs-directory` to change the location). These are rotated automatically, keeping the last 30 days by default (`--logs-to-keep`).
 
 ## Optional Functionality
 
@@ -147,21 +139,23 @@ CVD-Update will write logs to the `~/.cvdupdate/logs` directory, which is why I 
 
 DNS is required for CVD-Update to function properly (to gather the TXT record containing the current definition database version). You can select a specific nameserver to ensure said nameserver is used when querying the TXT record containing the current database definition version available
 
-1. Set the nameserver in the config. Eg:
+1. Set the nameservers in the config. Eg:
 
    ```bash
-   cvd config set --nameserver 208.67.222.222
+   cvd config set --nameservers 208.67.222.222
    ```
 
-2. Set the environment variable `CVDUPDATE_NAMESERVER`. Eg:
+2. Set the environment variable `CVDUPDATE_NAMESERVERS`. Eg:
 
    ```bash
-   CVDUPDATE_NAMESERVER="208.67.222.222" cvd update
+   CVDUPDATE_NAMESERVERS="208.67.222.222" cvd update
    ```
 
 The environment variable will take precedence over the nameserver config setting.
 
 Note:  Both options can be used to provide a comma-delimited list of nameservers to utilize for resolution.
+
+> _Note_: The `--nameserver` flag and the `CVDUPDATE_NAMESERVER` environment variable (singular) from CVD-Update &le; 1.2.0 are still accepted as deprecated aliases for `--nameservers` / `CVDUPDATE_NAMESERVERS`, but will be removed in a future release.
 
 ### Using a proxy
 
@@ -170,7 +164,7 @@ Depending on your type of proxy, you may be able to use CVD-Update with your pro
 First, set a custom domain name server to use the proxy:
 
 ```bash
-cvd config set --nameserver <proxy_ip>
+cvd config set --nameservers <proxy_ip>
 ```
 
 Then run CVD-Update like this:
@@ -226,16 +220,69 @@ cvd add --help
 cvd clean --help
 ```
 
-Print out the current list of databases.
+Print out the current list of database names.
 
 ```bash
-cvd list -V
+cvd list
 ```
+
+Print out the status (versions, last-checked times, URLs) of all databases, or a single one.
+
+```bash
+cvd status
+cvd status daily.cvd
+```
+
+> _Note_: `status` replaces the old `show` command. `show` still works as a deprecated alias and will be removed in a future release. Add `--json` to `status` (and `list`) for machine-readable output.
 
 Print out the config to see what it looks like.
 
 ```bash
 cvd config show
+```
+
+### Command aliases and JSON output
+
+The common commands have short aliases:
+
+| Command  | Alias |
+|----------|-------|
+| `status` | `s`   |
+| `update` | `u`   |
+| `list`   | `ls`  |
+| `remove` | `rm`  |
+| `config` | `cf`  |
+| `clean`  | `cl`  |
+
+`list`, `status`, and `config show` accept `--json` to emit machine-readable output for scripting:
+
+```bash
+cvd list --json                # JSON array of database names
+cvd status --json              # full state for all databases
+cvd status daily.cvd --json    # state for a single database
+cvd config show --json         # current configuration
+```
+
+### Configuration options
+
+`cvd config set` exposes every configuration option. Run with no options to see the help. Booleans use a `--flag` / `--no-flag` pair.
+
+| Option | Description |
+|--------|-------------|
+| `--nameservers`, `-n` | Comma-separated DNS nameservers used for the version check. |
+| `--max-retries` | Download retries, `1`–`5` (default `3`). |
+| `--logs-enabled` / `--no-logs-enabled` | Write log files to the logs directory (default: off). |
+| `--logs-directory`, `-l` | Log directory path. |
+| `--logs-rotate` / `--no-logs-rotate` | Rotate (delete) old log files (default: on). |
+| `--logs-to-keep` | Number of log files to keep when rotating (default `30`). |
+| `--dbs-directory`, `-d` | Database directory path (your HTTP server's `www` root). |
+| `--cdiffs-rotate` / `--no-cdiffs-rotate` | Rotate (delete) old CDIFF files (default: on). |
+| `--cdiffs-to-keep` | Number of CDIFFs to keep per database when rotating (default `30`). |
+| `--state-file` | Path to the state file (stores versions, UUID, and per-database metadata). |
+
+```bash
+# e.g. point databases at your web root and keep the state file alongside it
+cvd config set --dbs-directory /var/www/html/clamav --logs-enabled
 ```
 
 ### Do an update
@@ -249,7 +296,7 @@ cvd update -V
 List out the databases again:
 
 ```bash
-cvd list -V
+cvd status
 ```
 
 The print out the config again so you can see what's changed.
@@ -280,10 +327,16 @@ Maybe add an additional database that is not part of the default set of database
 cvd add linux.cvd https://database.clamav.net/linux.cvd
 ```
 
+To change the URL of a database that is already in the list, pass `--override`:
+
+```bash
+cvd add --override linux.cvd https://mirror.example.com/linux.cvd
+```
+
 List out the databases again:
 
 ```bash
-cvd list -V
+cvd status
 ```
 
 ### Serve it up, Test out FreshClam
@@ -300,55 +353,66 @@ DatabaseMirror http://localhost:8000
 
 ## Use docker
 
-Build docker image
+Build the image:
 
 ```bash
 docker build . --tag cvdupdate:latest
 ```
 
-Run image, that will automaticly update databases in folder `/srv/cvdupdate` and write logs to `/var/log/cvdupdate`
+Run it to keep the databases in a local `./database` directory updated on a schedule:
 
 ```bash
 docker run -d \
-  -v /srv/cvdupdate:/cvdupdate/database \
-  -v /var/log/cvdupdate:/cvdupdate/logs \
+  -v "$(pwd)/database:/cvdupdate/database" \
   cvdupdate:latest
 ```
 
-Run image, that will automaticly update databases in folder `/srv/cvdupdate`, write logs to `/var/log/cvdupdate` and set owner of files to user with ID 1000
+The container is configured with environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CRON` | `30 */4 * * *` | Update schedule (see [Cron Example](#cron-example)). |
+| `USER_ID` | `0` | UID that owns the files and runs the updater; set non-zero to avoid running as root. |
+| `ENABLE_LOGS` | unset | Set to any value other than `false` to write log files to `/cvdupdate/logs`. |
+| `LOGS_TO_KEEP` | `30` | Number of daily log files to keep (positive integer). |
+| `EXTRA_DATABASES` | unset | Comma-separated `<db_name>:<db_url>` entries to add on startup. |
+| `REMOVE_DATABASES` | unset | Comma-separated database names to remove on startup. |
+
+File logging is off by default — the container writes to `stdout`/`stderr`, which you can view with `docker logs`. If you also want log files on the host, enable file logging and mount the logs directory:
 
 ```bash
 docker run -d \
-  -v /srv/cvdupdate:/cvdupdate/database \
-  -v /var/log/cvdupdate:/cvdupdate/logs \
+  -v "$(pwd)/database:/cvdupdate/database" \
+  -v "$(pwd)/logs:/cvdupdate/logs" \
+  -e ENABLE_LOGS=true \
+  cvdupdate:latest
+```
+
+Run as a non-root user (UID 1000) and update once a day at midnight:
+
+```bash
+docker run -d \
+  -v "$(pwd)/database:/cvdupdate/database" \
   -e USER_ID=1000 \
-  cvdupdate:latest
-```
-
-Default update interval is `30 */4 * * *` (see [Cron Example](#cron-example))
-
-You may pass custom update interval in environment variable `CRON`
-
-For example - update every day in 00:00
-
-```bash
-docker run -d \
-  -v /srv/cvdupdate:/cvdupdate/database \
-  -v /var/log/cvdupdate:/cvdupdate/logs \
   -e CRON='0 0 * * *' \
   cvdupdate:latest
-  ```
+```
+
+Pass a command as arguments to run it once and exit, instead of starting the update cron. For example, a single update:
+
+```bash
+docker run --rm \
+  -v "$(pwd)/database:/cvdupdate/database" \
+  cvdupdate:latest cvdupdate update
+```
+
+Any `cvdupdate` command works this way (e.g. `cvdupdate status`, etc).
+
 ## Use Docker Compose
 
-A Docker `compose.yaml` is provided to:
+Example docker `compose.yaml` is provided to:
 1. Regularly update a Docker volume with the latest ClamAV databases.
 2. Serve a database mirror on port 8000 using the Apache webserver. 
-
-Edit the `compose.yaml` file if you need to change the default values:
-
-* Port 8000
-* USER_ID=0
-* CRON=30 */4 * * *
 
 ### Build
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -7,14 +7,24 @@ services:
     environment:
       - CRON=30 */4 * * *
       - USER_ID=0
+      - ENABLE_LOGS=true
+      - LOGS_TO_KEEP=10
+      # REMOVE_DATABASES - comma-separated list of databases names to remove on startup,
+      # f.e: custom_db1.hdb,custom_db2.hdb
+      - REMOVE_DATABASES=
+      # EXTRA_DATABASES - comma-separated list of additional databases to add on startup,
+      # f.e: custom_db1.hdb:http://mirror.example.com/custom_db1.hdb,custom_db2.hdb:http://mirror.example.com/custom_db2.hdb
+      - EXTRA_DATABASES=
     volumes:
       - database:/cvdupdate/database
       - log:/cvdupdate/logs
+
   ## Apache instance to serve the mirror
   apache:
     image: httpd:2.4
     volumes:
-      - database:/usr/local/apache2/htdocs
+      - ./compose/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+      - database:/cvdupdate/database:ro
     ports:
       - 8000:80
 

--- a/compose/httpd.conf
+++ b/compose/httpd.conf
@@ -4,6 +4,7 @@ Listen 80
 
 LoadModule mpm_event_module modules/mod_mpm_event.so
 LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule alias_module modules/mod_alias.so
 LoadModule autoindex_module modules/mod_autoindex.so
 LoadModule dir_module modules/mod_dir.so
 LoadModule log_config_module modules/mod_log_config.so
@@ -24,9 +25,9 @@ DocumentRoot "/cvdupdate/database"
     IndexIgnore .*
 </Directory>
 
-<FilesMatch "^\.">
-    Require all denied
-</FilesMatch>
+# 404 any dot-prefixed path segment, so dotfiles/dotdirs (e.g. the .state.json
+# state file or a .git dir) are hidden without confirming they exist.
+RedirectMatch 404 "(^|/)\."
 
 ErrorLog /proc/self/fd/2
 LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined

--- a/compose/httpd.conf
+++ b/compose/httpd.conf
@@ -1,0 +1,33 @@
+ServerName httpd
+ServerRoot "/usr/local/apache2"
+Listen 80
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule autoindex_module modules/mod_autoindex.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule unixd_module modules/mod_unixd.so
+
+User www-data
+Group www-data
+
+TypesConfig conf/mime.types
+
+DocumentRoot "/cvdupdate/database"
+
+<Directory "/cvdupdate/database">
+    Options Indexes FollowSymLinks
+    AllowOverride None
+    Require all granted
+    IndexIgnore .*
+</Directory>
+
+<FilesMatch "^\.">
+    Require all denied
+</FilesMatch>
+
+ErrorLog /proc/self/fd/2
+LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+CustomLog /proc/self/fd/1 combined

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -135,7 +135,7 @@ class AliasedGroup(click.Group):
         commands = []
         for name in self.list_commands(ctx):
             cmd = self.commands.get(name)
-            if cmd is None:
+            if cmd is None or cmd.hidden:
                 continue
             help_text = cmd.get_short_help_str(limit=formatter.width)
             aliases = self._reverse_alias.get(name, [])
@@ -194,15 +194,18 @@ def db_status(config: str, verbose: bool, use_json: bool, db: str):
     m = CVDUpdate(config=config, verbose=verbose)
     if db == "":
         if use_json:
-            print(_json.dumps(m.state, indent=4))
+            state_view = dict(m.state)
+            state_view['dbs'] = m._index_local_databases()
+            print(_json.dumps(state_view, indent=4))
         else:
             m.db_list()
     else:
         if use_json:
-            if db not in m.state['dbs']:
+            dbs = m._index_local_databases()
+            if db not in dbs:
                 m.logger.error(f"No such database: {db}")
                 sys.exit(1)
-            print(_json.dumps(m.state['dbs'][db], indent=4))
+            print(_json.dumps(dbs[db], indent=4))
         else:
             if not m.db_show(db):
                 sys.exit(1)

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -316,18 +316,25 @@ def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, log
         ("--logdir", logdir, "--logs-directory", logs_directory),
         ("--dbdir", dbdir, "--dbs-directory", dbs_directory),
     ):
-        if old_val != "":
-            click.echo(
-                f"Warning: '{old_flag}' is deprecated; use '{new_flag}' instead.",
-                err=True,
-            )
+        if old_val == "":
+            continue
+        click.echo(
+            f"Warning: '{old_flag}' is deprecated; use '{new_flag}' instead.",
+            err=True,
+        )
+        if new_flag == "--nameservers":
             if new_val == "":
-                if new_flag == "--nameservers":
-                    nameservers = old_val
-                elif new_flag == "--logs-directory":
-                    logs_directory = old_val
-                else:
-                    dbs_directory = old_val
+                nameservers = old_val
+        elif new_flag == "--logs-directory":
+            if new_val == "":
+                logs_directory = old_val
+            # The old --logdir implied file logging was enabled; preserve that
+            # unless the user explicitly set --logs-enabled/--no-logs-enabled.
+            if logs_enabled is None:
+                logs_enabled = True
+        else:  # --dbs-directory
+            if new_val == "":
+                dbs_directory = old_val
 
     no_options_set = (
         nameservers == ""

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -32,7 +32,9 @@ limitations under the License.
 import json as _json
 import logging
 import os
+import posixpath
 import sys
+from urllib.parse import unquote
 import click
 import colorlog
 try:
@@ -61,6 +63,38 @@ def _package_version() -> str:
         return _get_version('cvdupdate')
     except PackageNotFoundError:
         return '0.0'
+
+
+class MirrorRequestHandler(RangeRequestHandler):
+    """
+    RangeRequestHandler that hides dot-prefixed files and directories so the
+    `serve` test mirror doesn't expose hidden files (e.g. `.state.json`).
+    """
+
+    def send_head(self):
+        # Decode %xx (so /%2egit can't bypass the check) and normalize, then
+        # block any path segment that names a dotfile/dotdir — including files
+        # inside one (e.g. /.git/config), not just a dot-prefixed final segment.
+        # '.' and '..' are navigation segments, not hidden names.
+        path = posixpath.normpath(unquote(self.path.split('?', 1)[0].split('#', 1)[0]))
+        segments = [seg for seg in path.split('/') if seg not in ('.', '..')]
+        if any(seg.startswith('.') for seg in segments):
+            self.send_error(404, "File not found")
+            return None
+        return super().send_head()
+
+    def list_directory(self, path):
+        # Filter dot-prefixed entries out of auto-generated directory listings.
+        try:
+            names = os.listdir(path)
+        except OSError:
+            return super().list_directory(path)
+        original_listdir = os.listdir
+        os.listdir = lambda _p: [n for n in names if not n.startswith('.')]
+        try:
+            return super().list_directory(path)
+        finally:
+            os.listdir = original_listdir
 
 
 class AliasedGroup(click.Group):
@@ -174,6 +208,24 @@ def db_status(config: str, verbose: bool, use_json: bool, db: str):
                 sys.exit(1)
 
 
+@cli.command("show", hidden=True)
+@click.pass_context
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--json", "use_json", is_flag=True, default=False, help="Output as JSON.")
+@click.argument("db", required=False, default="")
+def db_show_deprecated(ctx, config: str, verbose: bool, use_json: bool, db: str):
+    """
+    (Deprecated) Alias for 'status'. Use 'status' instead.
+    """
+    click.echo(
+        "Warning: 'show' is deprecated and will be removed in a future release; "
+        "use 'status' instead.",
+        err=True,
+    )
+    ctx.forward(db_status)
+
+
 @cli.command("update", aliases=["u"])
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
@@ -246,14 +298,37 @@ def config():
               help="Number of CDIFF files to keep.")
 @click.option("--state-file", type=click.Path(), default="",
               help="Path to the state file.")
+# Deprecated flag names from <= 1.2.0, kept as hidden aliases for backward compatibility.
+@click.option("--nameserver", type=str, default="", hidden=True)
+@click.option("--logdir", type=click.Path(), default="", hidden=True)
+@click.option("--dbdir", type=click.Path(), default="", hidden=True)
 def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, logs_directory,
                logs_rotate, logs_to_keep, dbs_directory, cdiffs_rotate, cdiffs_to_keep,
-               state_file):
+               state_file, nameserver, logdir, dbdir):
     """
     Set configuration options.
 
     The default configuration directory is ~/.cvdupdate
     """
+    # Map deprecated (<= 1.2.0) flags onto their current equivalents.
+    for old_flag, old_val, new_flag, new_val in (
+        ("--nameserver", nameserver, "--nameservers", nameservers),
+        ("--logdir", logdir, "--logs-directory", logs_directory),
+        ("--dbdir", dbdir, "--dbs-directory", dbs_directory),
+    ):
+        if old_val != "":
+            click.echo(
+                f"Warning: '{old_flag}' is deprecated; use '{new_flag}' instead.",
+                err=True,
+            )
+            if new_val == "":
+                if new_flag == "--nameservers":
+                    nameservers = old_val
+                elif new_flag == "--logs-directory":
+                    logs_directory = old_val
+                else:
+                    dbs_directory = old_val
+
     no_options_set = (
         nameservers == ""
         and max_retries == 0
@@ -347,17 +422,20 @@ def clean_all(config: str, verbose: bool):
 @click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
 @click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 @click.option("--update-interval-seconds", "-U", type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
-@click.argument("port", type=int, required=False, default=0)
+@click.argument("port", type=int, required=False, default=8000)
 def serve(port: int, config: str, verbose: bool, update_interval_seconds: int):
     """
     Serve up the database directory for testing purposes only. Not a production quality server.
+
+    PORT defaults to 8000. Pass 0 to have the OS pick a random available port.
     """
     m = CVDUpdate(config=config, verbose=verbose)
     os.chdir(str(m.dbs_directory))
     auto_updater.start(update_interval_seconds)
 
-    RangeRequestHandler.protocol_version = 'HTTP/1.0'
-    httpd = HTTPServer(('', port), RangeRequestHandler)
+    # Don't expose hidden files (e.g. a dot-prefixed state file) over the mirror.
+    MirrorRequestHandler.protocol_version = 'HTTP/1.0'
+    httpd = HTTPServer(('', port), MirrorRequestHandler)
     actual_port = httpd.server_address[1]
     m.logger.info(f"Serving up {m.dbs_directory} on localhost:{actual_port}...")
     httpd.serve_forever()

--- a/cvdupdate/__main__.py
+++ b/cvdupdate/__main__.py
@@ -29,11 +29,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import json as _json
 import logging
 import os
 import sys
-from pathlib import Path
-
 import click
 import colorlog
 try:
@@ -53,10 +52,8 @@ handler.setFormatter(
     )
 )
 logging.basicConfig(level=logging.DEBUG, handlers=[handler])
-module_logger = logging.getLogger("cvdupdate")
-module_logger.setLevel(logging.DEBUG)
 
-from colorama import Fore, Back, Style
+from colorama import Fore, Style
 
 
 def _package_version() -> str:
@@ -65,10 +62,61 @@ def _package_version() -> str:
     except PackageNotFoundError:
         return '0.0'
 
+
+class AliasedGroup(click.Group):
+    """
+    A Click Group subclass that supports command aliases.
+    Aliases are shown inline in the help text: "name (alias1, alias2)".
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._alias_map = {}      # alias → primary command name
+        self._reverse_alias = {}  # primary → [alias, ...]
+        super().__init__(*args, **kwargs)
+
+    def command(self, *args, aliases=None, **kwargs):
+        def decorator(f):
+            cmd = super(AliasedGroup, self).command(*args, **kwargs)(f)
+            if aliases:
+                for alias in aliases:
+                    self._alias_map[alias] = cmd.name
+                    self._reverse_alias.setdefault(cmd.name, []).append(alias)
+            return cmd
+        return decorator
+
+    def group(self, *args, aliases=None, **kwargs):
+        def decorator(f):
+            cmd = super(AliasedGroup, self).group(*args, **kwargs)(f)
+            if aliases:
+                for alias in aliases:
+                    self._alias_map[alias] = cmd.name
+                    self._reverse_alias.setdefault(cmd.name, []).append(alias)
+            return cmd
+        return decorator
+
+    def get_command(self, ctx, cmd_name):
+        return super().get_command(ctx, self._alias_map.get(cmd_name, cmd_name))
+
+    def format_commands(self, ctx, formatter):
+        commands = []
+        for name in self.list_commands(ctx):
+            cmd = self.commands.get(name)
+            if cmd is None:
+                continue
+            help_text = cmd.get_short_help_str(limit=formatter.width)
+            aliases = self._reverse_alias.get(name, [])
+            display_name = f"{name} ({', '.join(aliases)})" if aliases else name
+            commands.append((display_name, help_text))
+        if commands:
+            with formatter.section("Commands"):
+                formatter.write_dl(commands)
+
+
 #
 # CLI Interface
 #
 @click.group(
+    cls=AliasedGroup,
     epilog=Fore.BLUE
     + __doc__ + "\n"
     + Fore.GREEN
@@ -81,32 +129,55 @@ def cli():
     pass
 
 
-@cli.command("list")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-def db_list(config: str, verbose: bool):
+@cli.command("list", aliases=["ls"])
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--json", "use_json", is_flag=True, default=False, help="Output as JSON array.")
+def db_list(config: str, verbose: bool, use_json: bool):
     """
-    List the DBs found in the database directory.
-    """
-    m = CVDUpdate(config=config, verbose=verbose)
-    m.db_list()
-
-@cli.command("show")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.argument("db", required=True)
-def db_show(config: str, verbose: bool, db: str):
-    """
-    Show details about a specific database.
+    List the DB names found in the database directory.
     """
     m = CVDUpdate(config=config, verbose=verbose)
-    if not m.db_show(db):
-        sys.exit(1)
+    names = list(m.state['dbs'].keys())
+    if use_json:
+        print(_json.dumps(names, indent=4))
+    else:
+        for name in names:
+            print(name)
 
-@cli.command("update")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.option("--debug-mode", "-D", is_flag=True, default=False, help="Print out HTTP headers for debugging purposes. [optional]")
+
+@cli.command("status", aliases=["s"])
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--json", "use_json", is_flag=True, default=False, help="Output as JSON.")
+@click.argument("db", required=False, default="")
+def db_status(config: str, verbose: bool, use_json: bool, db: str):
+    """
+    Show status of one or all databases.
+
+    With DB argument: show that database. Without: show all.
+    """
+    m = CVDUpdate(config=config, verbose=verbose)
+    if db == "":
+        if use_json:
+            print(_json.dumps(m.state, indent=4))
+        else:
+            m.db_list()
+    else:
+        if use_json:
+            if db not in m.state['dbs']:
+                m.logger.error(f"No such database: {db}")
+                sys.exit(1)
+            print(_json.dumps(m.state['dbs'][db], indent=4))
+        else:
+            if not m.db_show(db):
+                sys.exit(1)
+
+
+@cli.command("update", aliases=["u"])
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--debug-mode", "-D", is_flag=True, default=False, help="Print out HTTP headers for debugging purposes.")
 @click.argument("db", required=False, default="")
 def db_update(config: str, verbose: bool, db: str, debug_mode: bool):
     """
@@ -117,22 +188,25 @@ def db_update(config: str, verbose: bool, db: str, debug_mode: bool):
     if errors > 0:
         sys.exit(errors)
 
+
 @cli.command("add")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--override", is_flag=True, default=False, help="Update URL if DB already exists.")
 @click.argument("db", required=True)
 @click.argument("url", required=True)
-def db_add(config: str, verbose: bool, db: str, url: str):
+def db_add(config: str, verbose: bool, override: bool, db: str, url: str):
     """
     Add a db to the list of known DBs.
     """
     m = CVDUpdate(config=config, verbose=verbose)
-    if not m.config_add_db(db, url=url):
+    if not m.config_add_db(db, url=url, override=override):
         sys.exit(1)
 
-@cli.command("remove")
+
+@cli.command("remove", aliases=["rm"])
 @click.option("--config", "-c", type=str, required=False, default="")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 @click.argument("db", required=True)
 def db_remove(config: str, verbose: bool, db: str):
     """
@@ -143,47 +217,102 @@ def db_remove(config: str, verbose: bool, db: str):
         sys.exit(1)
 
 
-@cli.group(help="Commands to configure.")
+@cli.group(help="Commands to configure.", aliases=["cf"])
 def config():
     pass
 
-@config.command("set")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.option("--logdir", "-l", type=click.Path(), required=False, default="", help="Set a custom log directory. [optional]")
-@click.option("--dbdir", "-d", type=click.Path(), required=False, default="", help="Set a custom database directory. [optional]")
-@click.option("--nameserver", "-n", type=click.STRING, required=False, default="", help="Set a custom DNS nameserver. [optional]")
-def config_set(config: str, verbose: bool, logdir: str, dbdir: str, nameserver: str):
-    """
-    Set up first time configuration.
 
-    The default directories will be in ~/.cvdupdate
+@config.command("set")
+@click.pass_context
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config file path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--nameservers", "-n", type=str, default="",
+              help="Comma-separated list of DNS nameservers.")
+@click.option("--max-retries", type=int, default=0,
+              help="Maximum number of download retries (1-5, default 3).")
+@click.option("--logs-enabled/--no-logs-enabled", default=None,
+              help="Save logs to file.")
+@click.option("--logs-directory", "-l", type=click.Path(), default="",
+              help="Log directory path.")
+@click.option("--logs-rotate/--no-logs-rotate", default=None,
+              help="Rotate log files.")
+@click.option("--logs-to-keep", type=int, default=0,
+              help="Number of log files to keep.")
+@click.option("--dbs-directory", "-d", type=click.Path(), default="",
+              help="Database directory path.")
+@click.option("--cdiffs-rotate/--no-cdiffs-rotate", default=None,
+              help="Rotate CDIFF files.")
+@click.option("--cdiffs-to-keep", type=int, default=0,
+              help="Number of CDIFF files to keep.")
+@click.option("--state-file", type=click.Path(), default="",
+              help="Path to the state file.")
+def config_set(ctx, config, verbose, nameservers, max_retries, logs_enabled, logs_directory,
+               logs_rotate, logs_to_keep, dbs_directory, cdiffs_rotate, cdiffs_to_keep,
+               state_file):
     """
+    Set configuration options.
+
+    The default configuration directory is ~/.cvdupdate
+    """
+    no_options_set = (
+        nameservers == ""
+        and max_retries == 0
+        and logs_enabled is None
+        and logs_directory == ""
+        and logs_rotate is None
+        and logs_to_keep == 0
+        and dbs_directory == ""
+        and cdiffs_rotate is None
+        and cdiffs_to_keep == 0
+        and state_file == ""
+    )
+    if no_options_set:
+        click.echo(ctx.get_help())
+        return
     CVDUpdate(
         config=config,
         verbose=verbose,
-        log_dir=logdir,
-        db_dir=dbdir,
-        nameserver=nameserver)
+        nameservers=nameservers,
+        max_retries=max_retries,
+        logs_enabled=logs_enabled,
+        logs_directory=logs_directory,
+        logs_rotate=logs_rotate,
+        logs_to_keep=logs_to_keep,
+        dbs_directory=dbs_directory,
+        cdiffs_rotate=cdiffs_rotate,
+        cdiffs_to_keep=cdiffs_to_keep,
+        state_file=state_file,
+    )
+
 
 @config.command("show")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-def config_show(config: str, verbose: bool):
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
+@click.option("--json", "as_json", is_flag=True, default=False, help="Output as JSON.")
+def config_show(config: str, verbose: bool, as_json: bool):
     """
     Print out the current configuration.
     """
     m = CVDUpdate(config=config, verbose=verbose)
-    m.config_show()
+    if as_json:
+        print(_json.dumps(m.config, indent=4))
+    else:
+        for key, value in m.config.items():
+            cli_key = key.replace('_', '-')
+            if value == "" or value is None:
+                print(f"{cli_key}:")
+            else:
+                print(f"{cli_key}: {value}")
 
 
-@cli.group(help="Commands to clean up.")
+@cli.group(help="Commands to clean up.", aliases=["cl"])
 def clean():
     pass
 
+
 @clean.command("dbs")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 def clean_dbs(config: str, verbose: bool):
     """
     Delete all files in the database directory.
@@ -191,9 +320,10 @@ def clean_dbs(config: str, verbose: bool):
     m = CVDUpdate(config=config, verbose=verbose)
     m.clean_dbs()
 
+
 @clean.command("logs")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 def clean_logs(config: str, verbose: bool):
     """
     Delete all files in the logs directory
@@ -201,9 +331,10 @@ def clean_logs(config: str, verbose: bool):
     m = CVDUpdate(config=config, verbose=verbose)
     m.clean_logs()
 
+
 @clean.command("all")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 def clean_all(config: str, verbose: bool):
     """
     Delete the logs, databases, and config file.
@@ -213,67 +344,23 @@ def clean_all(config: str, verbose: bool):
 
 
 @cli.command("serve")
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
+@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path.")
+@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output.")
 @click.option("--update-interval-seconds", "-U", type=click.INT, required=False, default=0, help="Time in seconds before the next database update")
-@click.argument("port", type=int, required=False, default=8000)
+@click.argument("port", type=int, required=False, default=0)
 def serve(port: int, config: str, verbose: bool, update_interval_seconds: int):
     """
-    Serve up the database directory. Not a production quality server.
-    Intended for testing purposes.
+    Serve up the database directory for testing purposes only. Not a production quality server.
     """
     m = CVDUpdate(config=config, verbose=verbose)
-    os.chdir(str(m.db_dir))
-    m.logger.info(f"Serving up {m.db_dir} on localhost:{port}...")
+    os.chdir(str(m.dbs_directory))
     auto_updater.start(update_interval_seconds)
 
     RangeRequestHandler.protocol_version = 'HTTP/1.0'
-    # TODO(danvk): pick a random, available port
     httpd = HTTPServer(('', port), RangeRequestHandler)
+    actual_port = httpd.server_address[1]
+    m.logger.info(f"Serving up {m.dbs_directory} on localhost:{actual_port}...")
     httpd.serve_forever()
-
-
-#
-# Command Aliases
-#
-@cli.command("list")
-@click.pass_context
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-def list_alias(ctx, config: str, verbose: bool):
-    """
-    List the DBs found in the database directory.
-
-    This is just an alias for `db list`.
-    """
-    ctx.forward(db_list)
-
-@cli.command("show")
-@click.pass_context
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.argument("db", required=True)
-def show_alias(ctx, config: str, verbose: bool, db: str):
-    """
-    Show details about a specific database.
-
-    This is just an alias for `db show`.
-    """
-    ctx.forward(db_show)
-
-@cli.command("update")
-@click.pass_context
-@click.option("--config", "-c", type=click.Path(), required=False, default="", help="Config path. [optional]")
-@click.option("--verbose", "-V", is_flag=True, default=False, help="Verbose output. [optional]")
-@click.option("--debug-mode", "-D", is_flag=True, default=False, help="Print out HTTP headers for debugging purposes. [optional]")
-@click.argument("db", required=False, default="")
-def update_alias(ctx, config: str, verbose: bool, db: str, debug_mode: bool):
-    """
-    Update local copy of DBs.
-
-    This is just an alias for `db show`.
-    """
-    ctx.forward(db_update)
 
 
 if __name__ == "__main__":

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -80,9 +80,9 @@ class CVDUpdate:
         "cdiffs_rotate":  True,
         "cdiffs_to_keep": 30,
 
-        # Keep the state file out of the served database directory so `cvd serve`
-        # (and any external HTTP server) doesn't expose state metadata.
-        "state_file":     str(Path.home() / ".cvdupdate" / "state.json"),
+        # Resolved at load time to "<config dir>/state.json" when not set, so it
+        # stays next to the config (and out of the served database directory).
+        "state_file":     "",
     }
 
     default_state: dict = {
@@ -253,11 +253,15 @@ class CVDUpdate:
             self.config = copy.deepcopy(self.default_config)
             need_save = True
 
-        # Load state early to apply migration in one block.
-        # Support both old ("state file") and new ("state_file") key name.
-        state_file_str = (self.config.get("state_file")
-                          or self.config.get("state file")
-                          or self.default_config["state_file"])
+        # Resolve the state file location and load state early to apply
+        # migration in one block. Support both old ("state file") and new
+        # ("state_file") key names. When not configured, default it next to the
+        # config file (matches <= 1.2.0: custom --config paths get a colocated
+        # state file) and out of the served database directory.
+        state_file_str = self.config.get("state_file") or self.config.get("state file")
+        if not state_file_str:
+            state_file_str = str(self.config_path.parent / "state.json")
+        self.config["state_file"] = state_file_str
         state_path = Path(state_file_str)
         if state_path.exists():
             with state_path.open('r') as st_fi:

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -25,7 +25,6 @@ import logging
 import os
 import platform
 import re
-import subprocess
 import sys
 import time
 import uuid
@@ -69,18 +68,19 @@ class CVDUpdate:
     default_config_path: Path = Path.home() / ".cvdupdate" / "config.json"
 
     default_config: dict = {
-        "nameserver" : "",
-        "max retry" : 3, # No `cvd config set` option to set this, because we don't
-                         # _really_ want people hammering the CDN with partial downloads.
+        "nameservers":    "",
+        "max_retries":    3,
 
-        "log directory" : str(Path.home() / ".cvdupdate" / "logs"),
-        "rotate logs" : True,
-        "# logs to keep" : 30,
+        "logs_enabled":   False,
+        "logs_directory": str(Path.home() / ".cvdupdate" / "logs"),
+        "logs_rotate":    True,
+        "logs_to_keep":   30,
 
-        "db directory" : str(Path.home() / ".cvdupdate" / "database"),
-        "rotate cdiffs" : True,
-        "# cdiffs to keep" : 30,
-        "state file": "",
+        "dbs_directory":  str(Path.home() / ".cvdupdate" / "database"),
+        "cdiffs_rotate":  True,
+        "cdiffs_to_keep": 30,
+
+        "state_file":     str(Path.home() / ".cvdupdate" / "database" / "state.json"),
     }
 
     default_state: dict = {
@@ -118,25 +118,40 @@ class CVDUpdate:
     config_path: Path
     config: dict
     state: dict
-    db_dir: Path
-    log_dir: Path
+    dbs_directory: Path
+    logs_directory: Path
     version: str
 
     def __init__(
         self,
-        config: str  = "",
-        log_dir: str = "",
-        db_dir: str  = "",
-        nameserver: str  = "",
-        verbose: bool = False,
+        config: str         = "",
+        nameservers: str    = "",
+        max_retries: int    = 0,
+        logs_enabled: bool  = None,
+        logs_directory: str = "",
+        logs_rotate: bool   = None,
+        logs_to_keep: int   = 0,
+        dbs_directory: str  = "",
+        cdiffs_rotate: bool = None,
+        cdiffs_to_keep: int = 0,
+        state_file: str     = "",
+        verbose: bool       = False,
     ) -> None:
         """
         CVDUpdate class.
 
         Args:
-            log_dir:        path output log.
-            db_dir:         path where databases will be downloaded.
-            verbose:        Enable DEBUG-level logs and other verbose messages.
+            nameservers:    Comma-separated list of DNS nameservers.
+            max_retries:    Maximum number of download retries. Default: 3, must be between 1 and 5.
+            logs_enabled:   Save logs to file. Default: False.
+            logs_directory: Path for log output.
+            logs_rotate:    Rotate log files. Default: True.
+            logs_to_keep:   Number of log files to keep. Default: 30.
+            dbs_directory:  Path where databases will be downloaded.
+            cdiffs_rotate:  Rotate CDIFF files. Default: True.
+            cdiffs_to_keep: Number of CDIFF files to keep. Default: 30.
+            state_file:     Path to the state file.
+            verbose:        Enable DEBUG-level logs. Default: False.
         """
         try:
             self.version = _get_version('cvdupdate')
@@ -145,9 +160,16 @@ class CVDUpdate:
         self.verbose = verbose
         self._read_config(
             config,
-            db_dir,
-            log_dir,
-            nameserver)
+            nameservers,
+            max_retries,
+            logs_enabled,
+            logs_directory,
+            logs_rotate,
+            logs_to_keep,
+            dbs_directory,
+            cdiffs_rotate,
+            cdiffs_to_keep,
+            state_file)
         self._init_logging()
 
     def _init_logging(self) -> None:
@@ -155,23 +177,8 @@ class CVDUpdate:
         Initializes the logging parameters.
         """
         today = datetime.datetime.now()
-        log_file = self.log_dir / f"{today:%Y-%m-%d}.log"
-
-        if not self.log_dir.exists():
-            # Make a new log directory
-            os.makedirs(log_file.parent)
-        else:
-            # Log dir already exists, lets check if we need to prune old logs
-            logs = self.log_dir.glob('*.log')
-            for log in logs:
-                log_date_str = str(log.stem)
-                log_date = datetime.datetime.strptime(log_date_str, "%Y-%m-%d")
-                if log_date + datetime.timedelta(days=self.config["# logs to keep"]) < today:
-                    # Log is too old, delete!
-                    os.remove(str(log))
 
         stderr_level = logging.WARNING
-
         stderr_handler = logging.StreamHandler(sys.stderr)
         stderr_handler.setLevel(stderr_level)
 
@@ -182,16 +189,27 @@ class CVDUpdate:
         stdout_handler = logging.StreamHandler(sys.stdout)
         stdout_handler.addFilter(FilterNotStdErr())
 
+        handlers: list = [stderr_handler, stdout_handler]
+
+        if self.config["logs_enabled"]:
+            log_file = self.logs_directory / f"{today:%Y-%m-%d}.log"
+
+            if not self.logs_directory.exists():
+                os.makedirs(self.logs_directory)
+            elif self.config["logs_rotate"]:
+                for log in self.logs_directory.glob('*.log'):
+                    log_date = datetime.datetime.strptime(log.stem, "%Y-%m-%d")
+                    if log_date + datetime.timedelta(days=self.config["logs_to_keep"]) < today:
+                        os.remove(str(log))
+
+            handlers.append(logging.FileHandler(log_file))
+
         logging.basicConfig(
             level=logging.DEBUG if self.verbose else logging.INFO,
             format="%(asctime)s - %(levelname)s:  %(message)s",
             datefmt="%Y-%m-%d %I:%M:%S %p",
             force=True,  # an import might already have the root logger configured
-            handlers=[
-                stderr_handler,
-                stdout_handler,
-                logging.FileHandler(log_file),
-            ],
+            handlers=handlers,
         )
 
         self.logger = logging.getLogger(f"cvdupdate-{self.version}")
@@ -203,9 +221,16 @@ class CVDUpdate:
 
     def _read_config(self,
                      config: str,
-                     db_dir: str,
-                     log_dir: str,
-                     nameserver: str) -> None:
+                     nameservers: str,
+                     max_retries: int,
+                     logs_enabled: Optional[bool],
+                     logs_directory: str,
+                     logs_rotate: Optional[bool],
+                     logs_to_keep: int,
+                     dbs_directory: str,
+                     cdiffs_rotate: Optional[bool],
+                     cdiffs_to_keep: int,
+                     state_file: str) -> None:
         """
         Read in the config file.
         Create a new one if one does not already exist.
@@ -226,56 +251,95 @@ class CVDUpdate:
             self.config = copy.deepcopy(self.default_config)
             need_save = True
 
-        if db_dir != "":
-            self.config["db directory"] = db_dir
-            need_save = True
-        self.db_dir = Path(self.config["db directory"])
-
-        if log_dir != "":
-            self.config["log directory"] = log_dir
-            need_save = True
-        self.log_dir = Path(self.config["log directory"])
-
-        if nameserver != "":
-            self.config['nameserver'] = nameserver
-            need_save = True
-
-        # For backwards compatibility with older configs.
-        if 'nameserver' not in self.config:
-            self.config['nameserver'] = ""
-            need_save = True
-        if 'max retry' not in self.config:
-            self.config['max retry'] = 3
-            need_save = True
-
-        if not hasattr(self, 'state'):
-            self.state = {}
-
-        # keep database state in a separate file, defaulting to same dir as config file
-        if 'state file' not in self.config or self.config['state file'] == '':
-            self.config['state file'] = str(self.config_path.parent / "state.json")
-            need_save = True
-
-        # handle migration from config.json to state.json
-        if 'dbs' in self.config:
-            self.state['dbs'] = self.config['dbs']
-            del self.config['dbs']
-
-        if 'uuid' in self.config:
-            self.state['uuid'] = self.config['uuid']
-            del self.config['uuid']
-
-        state_file = Path(self.config['state file'])
-        if state_file.exists():
-            # state file exists, load it.
-            with state_file.open('r') as st_fi:
+        # Load state early to apply migration in one block.
+        # Support both old ("state file") and new ("state_file") key name.
+        state_file_str = (self.config.get("state_file")
+                          or self.config.get("state file")
+                          or self.default_config["state_file"])
+        state_path = Path(state_file_str)
+        if state_path.exists():
+            with state_path.open('r') as st_fi:
                 self.state = json.load(st_fi)
-        elif self.state == {} or 'dbs' not in self.state:
-            # state file does not exist
-            # so we either have a fresh install or we have a messed up json
-            # create a skeleton structure
+        else:
             self.state = copy.deepcopy(self.default_state)
             need_save = True
+
+        # --- Migration ---
+        # Rename v1.0.x space-separated keys to current underscore keys
+        _key_renames = {
+            "nameserver":       "nameservers",
+            "max retry":        "max_retries",
+            "log directory":    "logs_directory",
+            "rotate logs":      "logs_rotate",
+            "# logs to keep":   "logs_to_keep",
+            "db directory":     "dbs_directory",
+            "rotate cdiffs":    "cdiffs_rotate",
+            "# cdiffs to keep": "cdiffs_to_keep",
+            "state file":       "state_file",
+        }
+        for old_key, new_key in _key_renames.items():
+            # Ensure that if the old config had a "log directory" key, we also set "logs_enabled" to True for backward compatibility.
+            if old_key in self.config and old_key == "log directory":
+                self.config["logs_enabled"] = True
+            # Migrate from old key names to new one, but only if the old key exists and the new key doesn't already exist,
+            # to avoid overwriting any user-provided config values that are already in the new format.
+            if old_key in self.config:
+                if new_key not in self.config:
+                    self.config[new_key] = self.config[old_key]
+                del self.config[old_key]
+                need_save = True
+
+        # Fill in any new config keys absent from older configs
+        for key, default_val in self.default_config.items():
+            if key not in self.config:
+                self.config[key] = default_val
+                need_save = True
+
+        # Move dbs and uuid out of config into state
+        if 'dbs' in self.config:
+            self.state['dbs'] = self.config.pop('dbs')
+            need_save = True
+        if 'uuid' in self.config:
+            self.state['uuid'] = self.config.pop('uuid')
+            need_save = True
+        # --- End Migration ---
+
+        if nameservers != "":
+            self.config["nameservers"] = nameservers
+            need_save = True
+        if max_retries != 0:
+            self.config["max_retries"] = max_retries
+            need_save = True
+        if not 1 <= self.config["max_retries"] <= 5:
+            self.config["max_retries"] = self.default_config["max_retries"]
+            need_save = True
+        if logs_enabled is not None:
+            self.config["logs_enabled"] = logs_enabled
+            need_save = True
+        if logs_directory != "":
+            self.config["logs_directory"] = logs_directory
+            need_save = True
+        if logs_rotate is not None:
+            self.config["logs_rotate"] = logs_rotate
+            need_save = True
+        if logs_to_keep != 0:
+            self.config["logs_to_keep"] = logs_to_keep
+            need_save = True
+        if dbs_directory != "":
+            self.config["dbs_directory"] = dbs_directory
+            need_save = True
+        if cdiffs_rotate is not None:
+            self.config["cdiffs_rotate"] = cdiffs_rotate
+            need_save = True
+        if cdiffs_to_keep != 0:
+            self.config["cdiffs_to_keep"] = cdiffs_to_keep
+            need_save = True
+        if state_file != "":
+            self.config["state_file"] = state_file
+            need_save = True
+
+        self.dbs_directory = Path(self.config["dbs_directory"])
+        self.logs_directory = Path(self.config["logs_directory"])
 
         if 'uuid' not in self.state:
             # Create a UUID to put in our User-Agent for better (anonymous) metrics
@@ -289,7 +353,7 @@ class CVDUpdate:
         """
         Save the current configuration.
         """
-        for fi in (self.config_path, Path(self.config['state file'])):
+        for fi in (self.config_path, Path(self.config['state_file'])):
             if not fi.parent.exists():
                 # parent directory doesn't exist yet
                 try:
@@ -306,7 +370,7 @@ class CVDUpdate:
             raise exc
 
         try:
-            with open(self.config['state file'], 'w') as state_file:
+            with open(self.config['state_file'], 'w') as state_file:
                 json.dump(self.state, state_file, indent=4)
         except Exception as exc:
             print("Failed to create state file!")
@@ -314,21 +378,7 @@ class CVDUpdate:
 
         if self.verbose:
             print(f"Saved: {self.config_path}\n")
-            print(f"Saved: {self.config['state file']}\n")
-
-    def config_show(self):
-        """
-        Print out the config
-        """
-        print(f"Config file: {self.config_path}\n")
-        print(f"Config:\n{json.dumps(self.config, indent=4)}\n")
-        print(f"State file: {self.config['state file']}\n")
-        print(f"State:\n{json.dumps(self.state, indent=4)}\n")
-
-    def update(self, db: str = "") -> bool:
-        """
-        Update a specific database or all the databases.
-        """
+            print(f"Saved: {self.config['state_file']}\n")
 
     def clean_dbs(self):
         """
@@ -336,7 +386,7 @@ class CVDUpdate:
         """
         dbs = self.state['dbs'].keys()
         for db in dbs:
-            cvddb = self.db_dir / db
+            cvddb = self.dbs_directory / db
             if cvddb.exists():
                 try:
                     self.logger.info(f"Deleting: {db}")
@@ -351,7 +401,7 @@ class CVDUpdate:
                     raise exc
 
         # Remove / clear all CDIFFs
-        cdiff_files = self.db_dir.glob('*.cdiff')
+        cdiff_files = self.dbs_directory.glob('*.cdiff')
         for cdiff in cdiff_files:
             try:
                 self.logger.info(f"Deleting CDIFF: {cdiff.name}")
@@ -379,7 +429,7 @@ class CVDUpdate:
         Delete all files in the log directory.
         """
         self.logger.info(f"Deleting log files...")
-        logs = self.log_dir.glob('*')
+        logs = self.logs_directory.glob('*')
         for log in logs:
             os.remove(str(log))
             print(f"Deleted: {log}")
@@ -394,15 +444,23 @@ class CVDUpdate:
 
         os.remove(str(self.config_path))
         print(f"Deleted: {self.config_path}")
-        os.remove(str(self.config['state file']))
-        print(f"Deleted: {self.config['state file']}")
+        os.remove(str(self.config['state_file']))
+        print(f"Deleted: {self.config['state_file']}")
 
     def _index_local_databases(self) -> dict:
         need_save = False
         dbs = copy.deepcopy(self.state['dbs'])
 
-        db_paths = self.db_dir.glob('*')
+        db_paths = self.dbs_directory.glob('*')
         for db in db_paths:
+            if db.name == 'dns.txt':
+                continue
+            if db.name.endswith('.json'):
+                # Ignore JSON files, which are probably configs or state files.
+                continue
+            if db.name.startswith('.'):
+                # Ignore hidden files (e.g. .DS_Store, .gitkeep).
+                continue
             if db.name.endswith('.cdiff') or db.name.endswith('.sign'):
                 # Ignore CDIFFs and sign files, they'll get printed later.
                 continue
@@ -437,7 +495,7 @@ class CVDUpdate:
                     # saving the CVD info to the config. Let's just update the version field.
                     self.logger.info(f"Found {db.name} in the DB directory, though it wasn't downloaded using this tool.")
                     try:
-                        dbs[db.name]['local version'] = self._get_cvd_version_from_file(self.db_dir / db.name)
+                        dbs[db.name]['local version'] = self._get_cvd_version_from_file(self.dbs_directory / db.name)
                         self.logger.info(f"Identified mysterious {db.name} version: {dbs[db.name]['local version']}")
 
                         # Add the version info for this mysteriously deposited CVD to our config.
@@ -568,12 +626,12 @@ class CVDUpdate:
         '''
         Determine user provided nameserver configuration
         '''
-        config_nameserver = self.config['nameserver']
-        env_nameserver = os.environ.get("CVDUPDATE_NAMESERVER")
+        config_nameserver = self.config['nameservers']
+        env_nameserver = os.environ.get("CVDUPDATE_NAMESERVERS")
 
         # Environment variable overrides the configuration setting
         if env_nameserver != None and env_nameserver != "":
-            self.logger.info(f"Found CVDUPDATE_NAMESERVER environment variable to provide nameservers: {env_nameserver}")
+            self.logger.info(f"Found CVDUPDATE_NAMESERVERS environment variable to provide nameservers: {env_nameserver}")
             return env_nameserver
         elif config_nameserver != None and config_nameserver != "":
             self.logger.info(f"Found configuration provided nameservers: {config_nameserver}")
@@ -590,7 +648,7 @@ class CVDUpdate:
 
         if self.dns_version_tokens == []:
             # Query DNS if we haven't already
-            for _attempt in range(self.config['max retry']):
+            for _attempt in range(self.config['max_retries']):
                 if self._query_dns_txt_entry():
                     break
                 # Pause before next attempt.
@@ -636,7 +694,7 @@ class CVDUpdate:
 
         retry = 0
         response = None
-        while retry < self.config['max retry']:
+        while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'Range': 'bytes=0-95',
@@ -708,7 +766,7 @@ class CVDUpdate:
 
         retry = 0
         response = None
-        while retry < self.config['max retry']:
+        while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'If-Modified-Since': ims,
@@ -740,7 +798,7 @@ class CVDUpdate:
                 self.logger.info(f"Downloaded {db}")
 
             try:
-                with (self.db_dir / db).open('wb') as new_db:
+                with (self.dbs_directory / db).open('wb') as new_db:
                     new_db.write(response.content)
 
                 # Update config w/ new db info
@@ -750,7 +808,7 @@ class CVDUpdate:
 
             except Exception as exc:
                 self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
-                self.logger.error(f"Failed to save {db} to {self.db_dir}")
+                self.logger.error(f"Failed to save {db} to {self.dbs_directory}")
                 return CvdStatus.ERROR
 
         elif response.status_code == 304:
@@ -814,7 +872,7 @@ class CVDUpdate:
 
         retry = 0
         response = None
-        while retry < self.config['max retry']:
+        while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
             })
@@ -841,19 +899,19 @@ class CVDUpdate:
             # Download Success
             self.logger.info(f"Downloaded {file}")
             try:
-                with (self.db_dir / f"{file}").open('wb') as new_db:
+                with (self.dbs_directory / f"{file}").open('wb') as new_db:
                     new_db.write(response.content)
             except Exception as exc:
                 self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
-                self.logger.error(f"Failed to save {file} to {self.db_dir}.")
+                self.logger.error(f"Failed to save {file} to {self.dbs_directory}.")
 
             # Update config with CDIFF, for posterity
             self.state['dbs'][db]['CDIFFs'].append(file)
 
             # Prune old CDIFFs if needed
-            if len(self.state['dbs'][db]['CDIFFs']) > self.config['# cdiffs to keep']:
+            if len(self.state['dbs'][db]['CDIFFs']) > self.config['cdiffs_to_keep']:
                 try:
-                    os.remove(self.db_dir / self.state['dbs'][db]['CDIFFs'][0])
+                    os.remove(self.dbs_directory / self.state['dbs'][db]['CDIFFs'][0])
                 except Exception as exc:
                     self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
                     self.logger.debug(f"Tried to prune old cdiffs, but they weren't found, maybe someone else removed them already.")
@@ -914,7 +972,7 @@ class CVDUpdate:
             sign_file = f"{file_name}-{version}.{ext}.sign"
 
         # check if we already have it.
-        if (self.db_dir / sign_file).exists():
+        if (self.dbs_directory / sign_file).exists():
             self.logger.debug(f"We already have {sign_file}. Skipping...")
             return CvdStatus.NO_UPDATE
 
@@ -924,7 +982,7 @@ class CVDUpdate:
 
         retry = 0
         response = None
-        while retry < self.config['max retry']:
+        while retry < self.config['max_retries']:
             response = requests.get(url, headers = {
                 'User-Agent': f'CVDUPDATE/{self.version} ({self.state["uuid"]})',
                 'If-Modified-Since': ims,
@@ -956,12 +1014,12 @@ class CVDUpdate:
                 self.logger.info(f"Downloaded {sign_file}")
 
             try:
-                with (self.db_dir / sign_file).open('wb') as new_db:
+                with (self.dbs_directory / sign_file).open('wb') as new_db:
                     new_db.write(response.content)
 
             except Exception as exc:
                 self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
-                self.logger.error(f"Failed to save {sign_file} to {self.db_dir}")
+                self.logger.error(f"Failed to save {sign_file} to {self.dbs_directory}")
                 return CvdStatus.ERROR
 
         elif response.status_code == 304:
@@ -1021,7 +1079,7 @@ class CVDUpdate:
             #   https://database.clamav.net/daily-<version>.cdiff
             cdiff_file = f"{db[:-len('.cvd')]}-{desired_version}.cdiff"
 
-            if (self.db_dir / cdiff_file).exists():
+            if (self.dbs_directory / cdiff_file).exists():
                 self.logger.debug(f"We already have {cdiff_file}. Skipping...")
                 desired_version += 1
                 continue
@@ -1146,8 +1204,8 @@ class CVDUpdate:
         self.dns_version_tokens = []
 
         # Make sure we have a database directory to save files to
-        if not self.db_dir.exists():
-            os.makedirs(self.db_dir)
+        if not self.dbs_directory.exists():
+            os.makedirs(self.dbs_directory)
 
         # Check if there is a newer version of CVD-Update
         self.pypi_update_check()
@@ -1187,11 +1245,11 @@ class CVDUpdate:
                 # It's a CVD (official signed clamav database)
                 advertised_version = 0
 
-                if (self.db_dir / db).exists():
+                if (self.dbs_directory / db).exists():
                     if self.state['dbs'][db]['local version'] == 0:
                         # Seems like we somehow got a CVD in our database directory without
                         # saving the CVD info to the config. Let's just update the version field.
-                        self.state['dbs'][db]['local version'] = self._get_cvd_version_from_file(self.db_dir / db)
+                        self.state['dbs'][db]['local version'] = self._get_cvd_version_from_file(self.dbs_directory / db)
                 else:
                     if self.state['dbs'][db]['local version'] != 0:
                         # We have a local version but no CVD in the database directory.
@@ -1255,15 +1313,16 @@ class CVDUpdate:
         self._save_config()
 
         if self.update_errors == 0 and self.dbs_updated > 0:
-            with (self.db_dir / 'dns.txt').open('w') as dns_file:
+            with (self.dbs_directory / 'dns.txt').open('w') as dns_file:
                 dns_file.write(':'.join(self.dns_version_tokens))
-            self.logger.debug(f"Updated {self.db_dir / 'dns.txt'}")
+            self.logger.debug(f"Updated {self.dbs_directory / 'dns.txt'}")
 
         return self.update_errors
 
-    def config_add_db(self, db: str, url: str) -> bool:
+    def config_add_db(self, db: str, url: str, override: bool = False) -> bool:
         """
         Add another database + url to check when we update.
+        If override is True and the db already exists, update its URL.
         """
         extension = db.split('.')[-1]
         if extension not in [
@@ -1283,10 +1342,19 @@ class CVDUpdate:
             ]:
             self.logger.warning(f"{db} does not have valid clamav database file extension.")
 
-        if db in self.state['dbs']:
+        cmd = sys.argv[0]
+
+        if db in self.state['dbs'] and not override:
             self.logger.info(f"Cannot add {db}, it is already in our list.")
-            self.logger.info(f"Hint: Try `db list -V` or `db show {db}` for more information.")
+            self.logger.info(f"Hint: Try `{cmd} status {db}` for more information, use `{cmd} add --override {db} <url>` to update the URL.")
             return False
+
+        if db in self.state['dbs'] and override:
+            old_url = self.state['dbs'][db]['url']
+            self.state['dbs'][db]['url'] = url
+            self.logger.info(f"Updated URL for {db}: {old_url} -> {url}")
+            self._save_config()
+            return True
 
         self.state['dbs'][db] = {
             "url" : url,
@@ -1299,7 +1367,7 @@ class CVDUpdate:
         }
 
         self.logger.info(f"Added {db} ({url}) to DB list.")
-        self.logger.info(f"{db} will be downloaded next time you run `cvd update` or `cvd update {db}`")
+        self.logger.info(f"{db} will be downloaded next time you run `{cmd} update` or `{cmd} update {db}`")
 
         self._save_config()
 
@@ -1310,13 +1378,14 @@ class CVDUpdate:
         Remove a database from our list, and delete copies of the DB from the database directory.
         """
         if db not in self.state['dbs']:
+            cmd = sys.argv[0]
             self.logger.info(f"Cannot remove {db}, it is not in our list.")
-            self.logger.info(f"Hint: Try `db list -V` for more information.")
+            self.logger.info(f"Hint: Try `{cmd} status` for more information.")
             return False
 
         try:
-            if (self.db_dir / db).exists():
-                os.remove(str(self.db_dir / db))
+            if (self.dbs_directory / db).exists():
+                os.remove(str(self.dbs_directory / db))
                 self.logger.info(f"Deleted {db} from database directory.")
 
         except Exception as exc:
@@ -1325,8 +1394,8 @@ class CVDUpdate:
 
         for cdiff in self.state['dbs'][db]['CDIFFs']:
             try:
-                if (self.db_dir / cdiff).exists():
-                    os.remove(str(self.db_dir / cdiff))
+                if (self.dbs_directory / cdiff).exists():
+                    os.remove(str(self.dbs_directory / cdiff))
                     self.logger.info(f"Deleted {cdiff} from database directory.")
 
             except Exception as exc:

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -80,7 +80,9 @@ class CVDUpdate:
         "cdiffs_rotate":  True,
         "cdiffs_to_keep": 30,
 
-        "state_file":     str(Path.home() / ".cvdupdate" / "database" / "state.json"),
+        # Keep the state file out of the served database directory so `cvd serve`
+        # (and any external HTTP server) doesn't expose state metadata.
+        "state_file":     str(Path.home() / ".cvdupdate" / "state.json"),
     }
 
     default_state: dict = {
@@ -265,7 +267,7 @@ class CVDUpdate:
             need_save = True
 
         # --- Migration ---
-        # Rename v1.0.x space-separated keys to current underscore keys
+        # Rename legacy (<= 1.2.0) space-separated keys to current underscore keys
         _key_renames = {
             "nameserver":       "nameservers",
             "max retry":        "max_retries",
@@ -628,6 +630,15 @@ class CVDUpdate:
         '''
         config_nameserver = self.config['nameservers']
         env_nameserver = os.environ.get("CVDUPDATE_NAMESERVERS")
+
+        # Fall back to the deprecated singular variable for backward compatibility.
+        if env_nameserver is None or env_nameserver == "":
+            legacy_nameserver = os.environ.get("CVDUPDATE_NAMESERVER")
+            if legacy_nameserver is not None and legacy_nameserver != "":
+                self.logger.warning(
+                    "CVDUPDATE_NAMESERVER is deprecated; please use CVDUPDATE_NAMESERVERS instead."
+                )
+                env_nameserver = legacy_nameserver
 
         # Environment variable overrides the configuration setting
         if env_nameserver != None and env_nameserver != "":

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,16 +2,63 @@
 USER_ID="${USER_ID:-0}"
 SCRIPT_PATH=$(readlink -f "$0")
 echo "ClamAV Private Database Mirror Updater Cron ${SCRIPT_PATH}"
+CONFIG_ARGS=(--logs-directory /cvdupdate/logs --dbs-directory /cvdupdate/database --state-file /cvdupdate/database/.state.json)
+if [ -n "${ENABLE_LOGS}" ] && [ "${ENABLE_LOGS}" != "false" ]; then
+    CONFIG_ARGS+=( --logs-enabled)
+fi
+if [ -n "${LOGS_TO_KEEP}" ]; then
+    if [[ "${LOGS_TO_KEEP}" =~ ^[1-9][0-9]*$ ]]; then
+        CONFIG_ARGS+=( --logs-to-keep "${LOGS_TO_KEEP}")
+    else
+        echo "WARNING: LOGS_TO_KEEP must be a positive integer, got ${LOGS_TO_KEEP}, skipping"
+    fi
+fi
+
 if [ "${USER_ID}" -ne "0" ]; then
     echo "Creating user with ID ${USER_ID}"
     useradd --create-home --home-dir /cvdupdate --uid "${USER_ID}" cvdupdate
     chown -R "${USER_ID}" /cvdupdate
-    gosu cvdupdate cvdupdate config set --logdir /cvdupdate/logs
-    gosu cvdupdate cvdupdate config set --dbdir /cvdupdate/database
+    gosu cvdupdate cvdupdate config set "${CONFIG_ARGS[@]}"
 else
-    mkdir -p /cvdupdate/{logs,database}
-    cvdupdate config set --logdir /cvdupdate/logs
-    cvdupdate config set --dbdir /cvdupdate/database
+    mkdir -p /cvdupdate/database
+    if [ -n "${ENABLE_LOGS}" ] && [ "${ENABLE_LOGS}" != "false" ]; then
+        mkdir -p /cvdupdate/logs
+    fi
+    cvdupdate config set "${CONFIG_ARGS[@]}"
+fi
+
+if [ -n "${REMOVE_DATABASES}" ]; then
+    echo "Removing databases from REMOVE_DATABASES"
+    IFS=',' read -ra ENTRIES <<< "${REMOVE_DATABASES}"
+    for (( i=0; i<${#ENTRIES[@]}; i++ )); do
+        db_name="${ENTRIES[$i]}"
+        if [ -z "${db_name}" ]; then
+            continue
+        fi
+        if [ "${USER_ID}" -ne "0" ]; then
+            gosu cvdupdate cvdupdate remove "${db_name}"
+        else
+            cvdupdate remove "${db_name}"
+        fi
+    done
+fi
+
+if [ -n "${EXTRA_DATABASES}" ]; then
+    echo "Adding extra databases from EXTRA_DATABASES"
+    IFS=',' read -ra ENTRIES <<< "${EXTRA_DATABASES}"
+    for (( i=0; i<${#ENTRIES[@]}; i++ )); do
+        db_name="${ENTRIES[$i]%%:*}"
+        db_url="${ENTRIES[$i]#*:}"
+        if [ -z "${db_name}" ] || [ -z "${db_url}" ]; then
+            echo "WARNING: skipping malformed EXTRA_DATABASES entry: '${ENTRIES[$i]}' (expected <db_name>:<db_url>)"
+            continue
+        fi
+        if [ "${USER_ID}" -ne "0" ]; then
+            gosu cvdupdate cvdupdate add --override "${db_name}" "${db_url}"
+        else
+            cvdupdate add --override "${db_name}" "${db_url}"
+        fi
+    done
 fi
 
 if [ $# -eq 0 ]; then

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cvdupdate",
-    version="1.2.0",
+    version="1.3.0",
     author="The ClamAV Team",
     author_email="clamav-bugs@external.cisco.com",
     copyright="Copyright (C) 2025 Cisco Systems, Inc. and/or its affiliates. All rights reserved.",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import re
 import threading
 import http.client
 from http.server import HTTPServer
@@ -82,6 +83,23 @@ def test_status_single_unknown_json_exits_nonzero(revert_homedir, tmp_path):
     assert result.exit_code == 1
 
 
+def test_status_json_includes_local_dbs(revert_homedir, tmp_path):
+    # A DB file present on disk but not yet in state must appear in both the
+    # text and --json forms (both go through the indexed database view).
+    cfg = _init_config(tmp_path)
+    db_dir = tmp_path / 'database'
+    db_dir.mkdir(exist_ok=True)
+    (db_dir / 'local.hdb').write_bytes(b'signatures')
+
+    result = CliRunner().invoke(cli, ['status', '--config', cfg, '--json'])
+    assert result.exit_code == 0
+    assert 'local.hdb' in json.loads(result.output)['dbs']
+
+    single = CliRunner().invoke(cli, ['status', '--config', cfg, '--json', 'local.hdb'])
+    assert single.exit_code == 0
+    assert json.loads(single.output)['url'] == 'n/a'
+
+
 # --- aliases ---------------------------------------------------------------
 
 def test_short_aliases_resolve(revert_homedir, tmp_path):
@@ -100,6 +118,15 @@ def test_show_is_deprecated_alias_for_status(revert_homedir, tmp_path):
     assert 'deprecated' in _all_output(result).lower()
     # It should still show the requested database.
     assert 'daily.cvd' in result.output
+
+
+def test_show_is_hidden_from_help():
+    result = CliRunner().invoke(cli, ['--help'])
+    assert result.exit_code == 0
+    # `show` is a deprecated hidden alias; it must not be listed as a command.
+    assert not re.search(r'(?m)^\s+show\b', result.output)
+    # sanity: a visible command is still listed
+    assert re.search(r'(?m)^\s+status\b', result.output)
 
 
 def test_show_json_behaves_like_status(revert_homedir, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,241 @@
+import json
+import threading
+import http.client
+from http.server import HTTPServer
+
+from click.testing import CliRunner
+
+from tests.fixtures.revert import revert_homedir
+
+from cvdupdate.cvdupdate import CVDUpdate
+from cvdupdate.__main__ import cli, MirrorRequestHandler
+
+
+def _init_config(tmp_path):
+    """Create an isolated config + state in tmp_path and return the config path (str)."""
+    config_path = tmp_path / 'config.json'
+    CVDUpdate(
+        config=str(config_path),
+        state_file=str(tmp_path / 'state.json'),
+        dbs_directory=str(tmp_path / 'database'),
+    )
+    return str(config_path)
+
+
+def _load_config(tmp_path):
+    return json.loads((tmp_path / 'config.json').read_text())
+
+
+def _load_state(tmp_path):
+    return json.loads((tmp_path / 'state.json').read_text())
+
+
+def _all_output(result):
+    """Combined stdout+stderr, regardless of whether Click mixes the streams."""
+    text = result.output or ''
+    try:
+        err = result.stderr
+        if err:
+            text += err
+    except (ValueError, AttributeError):
+        # stderr was mixed into stdout already (older Click).
+        pass
+    return text
+
+
+# --- status / list ---------------------------------------------------------
+
+def test_list_prints_only_names(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['list', '--config', cfg])
+    assert result.exit_code == 0
+    names = set(result.output.split())
+    assert names == {'main.cvd', 'daily.cvd', 'bytecode.cvd'}
+
+
+def test_list_json_is_an_array(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['list', '--config', cfg, '--json'])
+    assert result.exit_code == 0
+    assert set(json.loads(result.output)) == {'main.cvd', 'daily.cvd', 'bytecode.cvd'}
+
+
+def test_status_all_json_matches_state(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['status', '--config', cfg, '--json'])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert set(payload['dbs'].keys()) == {'main.cvd', 'daily.cvd', 'bytecode.cvd'}
+
+
+def test_status_single_json(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['status', '--config', cfg, '--json', 'daily.cvd'])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload['url'] == 'https://database.clamav.net/daily.cvd'
+
+
+def test_status_single_unknown_json_exits_nonzero(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['status', '--config', cfg, '--json', 'nope.cvd'])
+    assert result.exit_code == 1
+
+
+# --- aliases ---------------------------------------------------------------
+
+def test_short_aliases_resolve(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    # 's' -> status, 'ls' -> list
+    assert CliRunner().invoke(cli, ['s', '--config', cfg, '--json']).exit_code == 0
+    ls = CliRunner().invoke(cli, ['ls', '--config', cfg, '--json'])
+    assert ls.exit_code == 0
+    assert set(json.loads(ls.output)) == {'main.cvd', 'daily.cvd', 'bytecode.cvd'}
+
+
+def test_show_is_deprecated_alias_for_status(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['show', '--config', cfg, 'daily.cvd'])
+    assert result.exit_code == 0
+    assert 'deprecated' in _all_output(result).lower()
+    # It should still show the requested database.
+    assert 'daily.cvd' in result.output
+
+
+def test_show_json_behaves_like_status(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['show', '--config', cfg, '--json', 'daily.cvd'])
+    assert result.exit_code == 0
+    # The deprecation warning goes to stderr; the JSON payload is still parseable
+    # from the tail of the combined output.
+    json_start = result.output.index('{')
+    payload = json.loads(result.output[json_start:])
+    assert payload['url'] == 'https://database.clamav.net/daily.cvd'
+
+
+# --- add --override --------------------------------------------------------
+
+def test_add_existing_without_override_fails(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(
+        cli, ['add', '--config', cfg, 'main.cvd', 'https://example.com/main.cvd'])
+    assert result.exit_code == 1
+    assert _load_state(tmp_path)['dbs']['main.cvd']['url'] == 'https://database.clamav.net/main.cvd'
+
+
+def test_add_existing_with_override_updates_url(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(
+        cli, ['add', '--config', cfg, '--override', 'main.cvd', 'https://example.com/main.cvd'])
+    assert result.exit_code == 0
+    assert _load_state(tmp_path)['dbs']['main.cvd']['url'] == 'https://example.com/main.cvd'
+
+
+# --- config set: deprecated flag aliases -----------------------------------
+
+def test_config_set_no_options_prints_help(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(cli, ['config', 'set', '--config', cfg])
+    assert result.exit_code == 0
+    assert 'Usage:' in result.output
+
+
+def test_config_set_deprecated_dbdir_maps_to_dbs_directory(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    new_dir = str(tmp_path / 'new-db-dir')
+    result = CliRunner().invoke(cli, ['config', 'set', '--config', cfg, '--dbdir', new_dir])
+    assert result.exit_code == 0
+    assert 'deprecated' in _all_output(result).lower()
+    assert _load_config(tmp_path)['dbs_directory'] == new_dir
+
+
+def test_config_set_deprecated_nameserver_maps_to_nameservers(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    result = CliRunner().invoke(
+        cli, ['config', 'set', '--config', cfg, '--nameserver', '208.67.222.222'])
+    assert result.exit_code == 0
+    assert 'deprecated' in _all_output(result).lower()
+    assert _load_config(tmp_path)['nameservers'] == '208.67.222.222'
+
+
+def test_config_set_deprecated_logdir_maps_and_enables_logging(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    new_dir = str(tmp_path / 'new-log-dir')
+    result = CliRunner().invoke(cli, ['config', 'set', '--config', cfg, '--logdir', new_dir])
+    assert result.exit_code == 0
+    assert 'deprecated' in _all_output(result).lower()
+    cfg_json = _load_config(tmp_path)
+    assert cfg_json['logs_directory'] == new_dir
+    # The old --logdir implied file logging was on; the alias must preserve that.
+    assert cfg_json['logs_enabled'] is True
+
+
+def test_config_set_logdir_respects_explicit_no_logs(revert_homedir, tmp_path):
+    cfg = _init_config(tmp_path)
+    new_dir = str(tmp_path / 'no-log-dir')
+    result = CliRunner().invoke(
+        cli, ['config', 'set', '--config', cfg, '--logdir', new_dir, '--no-logs-enabled'])
+    assert result.exit_code == 0
+    cfg_json = _load_config(tmp_path)
+    assert cfg_json['logs_directory'] == new_dir
+    assert cfg_json['logs_enabled'] is False
+
+
+# --- serve -----------------------------------------------------------------
+
+def test_serve_help_documents_default_and_random_port():
+    result = CliRunner().invoke(cli, ['serve', '--help'])
+    assert result.exit_code == 0
+    assert '8000' in result.output
+    assert 'random' in result.output.lower()
+
+
+def test_serve_handler_hides_dotfiles_and_dotdirs(tmp_path, monkeypatch):
+    db_dir = tmp_path / 'database'
+    db_dir.mkdir()
+    (db_dir / 'daily.cvd').write_bytes(b'CVD-DATA')
+    (db_dir / '.state.json').write_text('{"uuid": "secret"}')
+    (db_dir / '.hidden').write_text('nope')
+    dotdir = db_dir / '.git'
+    dotdir.mkdir()
+    (dotdir / 'config').write_text('secret')
+
+    monkeypatch.chdir(db_dir)
+
+    httpd = HTTPServer(('127.0.0.1', 0), MirrorRequestHandler)
+    port = httpd.server_address[1]
+    server_thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    server_thread.start()
+
+    def get(path):
+        conn = http.client.HTTPConnection('127.0.0.1', port)
+        try:
+            conn.request('GET', path)
+            resp = conn.getresponse()
+            return resp.status, resp.read()
+        finally:
+            conn.close()
+
+    try:
+        status, body = get('/daily.cvd')
+        assert status == 200
+        assert body == b'CVD-DATA'
+
+        assert get('/.state.json')[0] == 404
+        assert get('/.hidden')[0] == 404
+        # A file inside a dotdir must be blocked too, not just dot-prefixed files.
+        assert get('/.git/config')[0] == 404
+        # Percent-encoding the leading dot must not bypass the check.
+        assert get('/%2estate.json')[0] == 404
+        assert get('/%2egit/config')[0] == 404
+
+        status, listing = get('/')
+        assert status == 200
+        assert b'daily.cvd' in listing
+        assert b'.state.json' not in listing
+        assert b'.hidden' not in listing
+        assert b'.git' not in listing
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        server_thread.join(timeout=5)

--- a/tests/test_cvdupdate.py
+++ b/tests/test_cvdupdate.py
@@ -1,6 +1,6 @@
 import json
+import datetime
 from pathlib import Path
-import shutil
 
 from tests.fixtures.revert import revert_homedir
 
@@ -15,38 +15,46 @@ def test_alternate_config_locations(revert_homedir, tmp_path):
     default_cvdupdate_dir = Path.home() / '.cvdupdate'
     assert not default_cvdupdate_dir.exists()
 
-    # set the config file to be in pytests's /tmp/pytest-*
+    # set config and state to be in pytests's /tmp/pytest-*
     config_file_path = tmp_path / 'config.json'
-    c = CVDUpdate(config=config_file_path)
-
-    # verify the file is created and has default config data inside
-    assert config_file_path.exists()
-    txt = config_file_path.read_text()
-    assert txt
-    config_file_json = json.loads(txt)
-    assert config_file_json == c.config
-    # state file value will differ, so blank it out for comparing
-    c.config['state file'] = ''
-    assert c.config == c.default_config
-
-    # verify the state file is created and has default data inside
     state_file_path = tmp_path / 'state.json'
+    c = CVDUpdate(
+        config=config_file_path,
+        state_file=str(state_file_path),
+    )
+
+    # verify config file is created and matches in-memory config
+    assert config_file_path.exists()
+    assert json.loads(config_file_path.read_text()) == c.config
+    expected_config = {**c.default_config, 'state_file': str(state_file_path)}
+    assert c.config == expected_config
+
+    # verify state file is created and has the three default databases
     assert state_file_path.exists()
-    txt = state_file_path.read_text()
-    assert txt
-    state_file_json = json.loads(txt)
+    state_file_json = json.loads(state_file_path.read_text())
     assert state_file_json == c.state
-    # again, uuid will differ, so toss it out
+    assert set(state_file_json['dbs'].keys()) == {'main.cvd', 'daily.cvd', 'bytecode.cvd'}
     del c.state['uuid']
     assert c.state == c.default_state
 
-    # ~/.cvdupdate exists, because we haven't changed the logdir location
-    # but that's all it should have in it
-    default_cvdupdate_dir = Path.home() / '.cvdupdate'
-    assert default_cvdupdate_dir.exists()
-    children = list(default_cvdupdate_dir.iterdir())
-    assert len(children) == 1
-    assert children[0] == default_cvdupdate_dir / 'logs'
+    # logs are disabled by default, so ~/.cvdupdate should not be created at all
+    assert not default_cvdupdate_dir.exists()
+
+
+def test_logs_enabled(revert_homedir, tmp_path):
+    ''' Test that when logs_enabled=True, a dated log file is created in the logs directory '''
+    logs_dir_path = tmp_path / 'logs'
+    CVDUpdate(
+        config=tmp_path / 'config.json',
+        state_file=str(tmp_path / 'state.json'),
+        logs_enabled=True,
+        logs_directory=str(logs_dir_path),
+    )
+
+    assert logs_dir_path.exists()
+    log_files = list(logs_dir_path.iterdir())
+    assert len(log_files) == 1
+    assert log_files[0].name == f"{datetime.date.today():%Y-%m-%d}.log"
 
 
 def test_default_config_not_mutated(revert_homedir, tmp_path):
@@ -60,45 +68,73 @@ def test_default_config_not_mutated(revert_homedir, tmp_path):
     # set the config file to be in pytests /tmp/pytest-*
     b = CVDUpdate(config=config_file_path)
 
-    assert all(val == b.config[key] for key,val in a.config.items() if key != 'state file')
+    assert all(val == b.config[key] for key,val in a.config.items() if key != 'state_file')
     assert id(a.config) != id(b.config)
     assert id(a.default_config) == id(b.default_config) == id(CVDUpdate.default_config)
-    assert a.state != b.state
+    assert id(a.state) != id(b.state)
     assert id(a.default_state) == id(b.default_state)
 
 
-def test_existing_state_migrates_successfully(revert_homedir):
-    ''' specifically test migrating an existing config.json to config + state.json'''
+def test_v1_config_migrates_successfully(revert_homedir):
+    ''' Test that a v1.0.x config.json is migrated to the current format on load:
+    - old space-separated keys are renamed to underscore keys
+    - values are preserved across the rename
+    - dbs and uuid are moved out of config into a separate state.json
+    - new keys absent from the old config are filled in from defaults
+    - logs_enabled is set to True (old configs always had logging on)
+    '''
     default_cvdupdate_dir = Path.home() / '.cvdupdate'
     default_cvdupdate_dir.mkdir(parents=True)
 
-    # create a .cvdupdate/config.json which also contains dbs definitions
-    old_config_file = 'tests/files/v1.0.2.config.json'
-    old_config_json = json.loads(Path(old_config_file).read_text())
-    old_config_json["log directory"] = str(default_cvdupdate_dir / 'logs')
-    old_config_json["db directory"] = str(default_cvdupdate_dir / 'database')
+    logs_dir = str(default_cvdupdate_dir / 'logs')
+    db_dir   = str(default_cvdupdate_dir / 'database')
 
-    with (default_cvdupdate_dir / 'config.json').open('w') as test_config:
-        json.dump(old_config_json, test_config)
+    old_config = json.loads(Path('tests/files/v1.0.2.config.json').read_text())
+    old_config['log directory'] = logs_dir
+    old_config['db directory']  = db_dir
+    with (default_cvdupdate_dir / 'config.json').open('w') as f:
+        json.dump(old_config, f)
 
-    # create cvdupdate object, which will read config.json and split state into state.json
     a = CVDUpdate()
 
-    new_config_json = old_config_json
+    # --- key renames: old keys must be gone ---
+    old_keys = {'nameserver', 'max retry', 'log directory', 'rotate logs',
+                '# logs to keep', 'db directory', 'rotate cdiffs',
+                '# cdiffs to keep', 'dbs', 'uuid'}
+    assert old_keys.isdisjoint(a.config.keys())
 
-    # create expected state.json contents by copying the bits that move
-    new_state_json = {}
-    new_state_json['dbs'] = old_config_json['dbs']
-    new_state_json['uuid'] = old_config_json['uuid']
+    # --- key renames: values must be preserved ---
+    assert a.config['nameservers']    == old_config['nameserver']
+    assert a.config['max_retries']    == old_config['max retry']
+    assert a.config['logs_directory'] == logs_dir
+    assert a.config['logs_rotate']    == old_config['rotate logs']
+    assert a.config['logs_to_keep']   == old_config['# logs to keep']
+    assert a.config['dbs_directory']  == db_dir
+    assert a.config['cdiffs_rotate']  == old_config['rotate cdiffs']
+    assert a.config['cdiffs_to_keep'] == old_config['# cdiffs to keep']
 
-    # new update the config.json contents
-    del new_config_json['dbs']
-    del new_config_json['uuid']
-    new_config_json['state file'] = str(default_cvdupdate_dir / 'state.json')
+    # --- new keys must be filled in from defaults ---
+    assert a.config['state_file'] == CVDUpdate.default_config['state_file']
 
-    # compare actual result with expected transform
-    with open(default_cvdupdate_dir / 'config.json') as config:
-        assert new_config_json == json.loads(config.read())
-    with open(default_cvdupdate_dir / 'state.json') as state:
-        from pprint import pprint
-        assert new_state_json == json.loads(state.read())
+    # --- config must have exactly the current key set ---
+    assert a.config.keys() == CVDUpdate.default_config.keys()
+
+    # --- old config implies logs were always on: logs_enabled must be True and log file present ---
+    assert a.config['logs_enabled'] == True
+    log_files = list(Path(logs_dir).iterdir())
+    assert len(log_files) == 1
+    assert log_files[0].name == f"{datetime.date.today():%Y-%m-%d}.log"
+
+    # --- dbs and uuid must have been moved to state ---
+    assert a.state['dbs']  == old_config['dbs']
+    assert a.state['uuid'] == old_config['uuid']
+
+    # --- verify config.json on disk matches in-memory config ---
+    with (default_cvdupdate_dir / 'config.json').open() as f:
+        disk_config = json.load(f)
+    assert disk_config == a.config
+
+    # --- verify state.json on disk matches in-memory state ---
+    with Path(disk_config['state_file']).open() as f:
+        disk_state = json.load(f)
+    assert disk_state == a.state

--- a/tests/test_cvdupdate.py
+++ b/tests/test_cvdupdate.py
@@ -41,6 +41,24 @@ def test_alternate_config_locations(revert_homedir, tmp_path):
     assert not default_cvdupdate_dir.exists()
 
 
+def test_custom_config_colocates_state_file(revert_homedir, tmp_path):
+    ''' A custom config path without an explicit state file should default the
+    state file next to that config (as in <= 1.2.0), not in $HOME/.cvdupdate. '''
+    default_cvdupdate_dir = Path.home() / '.cvdupdate'
+    assert not default_cvdupdate_dir.exists()
+
+    config_dir = tmp_path / 'altconfig'
+    config_dir.mkdir()
+    config_file_path = config_dir / 'config.json'
+
+    c = CVDUpdate(config=str(config_file_path))
+
+    assert c.config['state_file'] == str(config_dir / 'state.json')
+    assert (config_dir / 'state.json').exists()
+    # the default ~/.cvdupdate must not be created for a custom config path
+    assert not default_cvdupdate_dir.exists()
+
+
 def test_logs_enabled(revert_homedir, tmp_path):
     ''' Test that when logs_enabled=True, a dated log file is created in the logs directory '''
     logs_dir_path = tmp_path / 'logs'
@@ -113,8 +131,8 @@ def test_v1_config_migrates_successfully(revert_homedir):
     assert a.config['cdiffs_rotate']  == old_config['rotate cdiffs']
     assert a.config['cdiffs_to_keep'] == old_config['# cdiffs to keep']
 
-    # --- new keys must be filled in from defaults ---
-    assert a.config['state_file'] == CVDUpdate.default_config['state_file']
+    # --- state_file defaults next to the config when not set ---
+    assert a.config['state_file'] == str(default_cvdupdate_dir / 'state.json')
 
     # --- config must have exactly the current key set ---
     assert a.config.keys() == CVDUpdate.default_config.keys()


### PR DESCRIPTION
## Summary

Changes for end user:
- cli arguments names changed
- config migrated to new format 
- writing of logs to directory disabled by default for new users (who not have old config)

Fixes #82 

### `cvdupdate/cvdupdate.py`
- All config keys normalized to `snake_case` (`logs_directory`, `dbs_directory`, etc.)
- `__init__` accepts all 11 config options as overridable parameters using sentinel defaults (`""` / `0` / `None` = don't override)
- `_read_config` applies sentinel-based overrides and persists only changed values
- `_init_logging` gates `FileHandler` creation behind `logs_enabled`
- `config_add_db` supports `override=False` parameter for `--override` flag
- `max_retries` clamped to range 1–5 on load; out-of-range values (including persisted ones) are reset to default `3`
- Removed dead code: empty `update()` stub, `config_show()` method, `import subprocess`

### `cvdupdate/__main__.py`
- Added `AliasedGroup(click.Group)` — aliases resolved transparently and displayed inline in help: `status (s)`, `update (u)`, `list (ls)`, `remove (rm)`, `config (cf)`, `clean (cl)`
- `config set` exposes all 12 config options; falls back to `--help` when called with no options
- `config show` outputs only the config JSON (removed state section)
- `status` replaces `list` logic when called without argument, support `--json` argument to display status file, when called with name of database - only 1 db status will be shown (also support `--json` argument
- `list` now only provide names of dbs to simplify parsing
- added `--override` flag for `add` so user can adjust remote URL for existing database   
- `serve` defaults to port `0` (OS picks a free port); actual port logged after bind
- Removed dead code: `from pathlib import Path`, `Back` from colorama, `module_logger`

### `scripts/docker-entrypoint.sh`
- Updated CLI flags to match new names: `--logs-directory`, `--dbs-directory`
- Config args built as a `CONFIG_ARGS` array shared across root/non-root branches
- `ENABLE_LOGS` — enables file logging when set to any value except `false`
- `LOGS_TO_KEEP` — sets log rotation count; validated as a positive integer (`^[1-9][0-9]*$`), warns and skips on invalid
- `EXTRA_DATABASES` — comma-separated `<db_name>:<db_url>` entries, calls `cvdupdate add --override` for each; validates both fields present
- `REMOVE_DATABASES` — comma-separated db names, calls `cvdupdate remove` for each
- Both loops use index-based iteration to avoid word-splitting issues

### `compose/httpd.conf` + `compose.yaml`
- New minimal Apache config: `DocumentRoot /cvdupdate/database` with `Options Indexes` for directory listing, previously this listing of files in directory was not possible
- `compose.yaml` mounts `./compose/httpd.conf` into the existing `apache` service
