### PR TITLE
fix(signatures): use origin URL basename for remote .sign downloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,12 @@
 
   [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/92)
 
+- 🐛 Fixed cleanup so pruning an old `.cdiff` or removing a database also
+  deletes its matching `.sign` file, keeping rotated files fully removed from
+  the mirror.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/92)
+
 ## Version 1.3.0
 
 - ➕ Added a `cvd status` command (alias `s`) that reports the status of all

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,20 @@
 > - Fixed: 🐛
 > - Security: 🛡
 
+## Version 1.3.1
+
+- 🐛 Fixed signature download behavior for mirrored databases with custom local
+  names: the remote `.sign` filename is now derived from the origin URL, while
+  the downloaded signature is still saved locally as `<local-db-name>.sign`.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/92)
+
+- 🐛 Added regression tests to verify origin-name vs local-name signature
+  handling, with mocked HTTP and a socket-level guard to ensure tests do not
+  perform real network connections.
+
+  [GitHub Pull-Request](https://github.com/Cisco-Talos/cvdupdate/pull/92)
+
 ## Version 1.3.0
 
 - ➕ Added a `cvd status` command (alias `s`) that reports the status of all

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -970,32 +970,40 @@ class CVDUpdate:
     def _download_sign_file_for(self, file: str, file_url: str, last_modified: int, version=0) -> CvdStatus:
         '''
         Download signature file given a file name.
-        If version > 0, will ensure sign file includes version in the filename, like this:
-        - file-version.ext.sign
+        Save the signature locally as "<local file>.sign", but derive the remote
+        signature filename from the origin URL basename.
         '''
         ims: str = datetime.datetime.fromtimestamp(last_modified, tz=datetime.timezone.utc).strftime('%a, %d %b %Y %H:%M:%S GMT')
 
-        sign_file = file + ".sign"
-        if version > 0 and str(version) not in file:
-            # the sign file name should include the version in this format: "file-version.ext.sign"
-            # reconstruct.
-            name_parts = file.rsplit('.', 1)
+        local_sign_file = file + ".sign"
+
+        # Determine the origin file name from URL path (ignore query string/fragments).
+        remote_file = file_url.rsplit('/', 1)[-1].split('?', 1)[0].split('#', 1)[0]
+        if remote_file == "":
+            self.logger.error(f"Invalid URL for signature download: {file_url}")
+            return CvdStatus.ERROR
+
+        remote_sign_file = remote_file + ".sign"
+        if version > 0 and str(version) not in remote_file:
+            # The remote sign file may include a version in this format:
+            # "origin-file-version.ext.sign"
+            name_parts = remote_file.rsplit('.', 1)
             if len(name_parts) == 1:
-                self.logger.error(f"Invalid file name. Lacks extension: {file}")
+                self.logger.error(f"Invalid origin file name. Lacks extension: {remote_file}")
                 return CvdStatus.ERROR
 
             file_name = name_parts[0]
             ext = name_parts[-1]
-            sign_file = f"{file_name}-{version}.{ext}.sign"
+            remote_sign_file = f"{file_name}-{version}.{ext}.sign"
 
         # check if we already have it.
-        if (self.dbs_directory / sign_file).exists():
-            self.logger.debug(f"We already have {sign_file}. Skipping...")
+        if (self.dbs_directory / local_sign_file).exists():
+            self.logger.debug(f"We already have {local_sign_file}. Skipping...")
             return CvdStatus.NO_UPDATE
 
-        # now remove the old file name from the file_url and add the new sign file name
+        # now remove the old file name from the file_url and add the origin sign file name
         base_url = file_url.rsplit('/', 1)[0]
-        url = f"{base_url}/{sign_file}"
+        url = f"{base_url}/{remote_sign_file}"
 
         retry = 0
         response = None
@@ -1021,32 +1029,32 @@ class CVDUpdate:
         if response.status_code == 200:
             # Looks like we downloaded something...
             if (('content-length' in response.headers) and int(response.headers['content-length']) > len(response.content)):
-                self.logger.error(f"Failed to download {sign_file}")
+                self.logger.error(f"Failed to download {remote_sign_file}")
                 return CvdStatus.ERROR
 
             # Download Success
             if version > 0:
-                self.logger.info(f"Downloaded {sign_file}. Version: {version}")
+                self.logger.info(f"Downloaded {remote_sign_file}. Version: {version}")
             else:
-                self.logger.info(f"Downloaded {sign_file}")
+                self.logger.info(f"Downloaded {remote_sign_file}")
 
             try:
-                with (self.dbs_directory / sign_file).open('wb') as new_db:
+                with (self.dbs_directory / local_sign_file).open('wb') as new_db:
                     new_db.write(response.content)
 
             except Exception as exc:
                 self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
-                self.logger.error(f"Failed to save {sign_file} to {self.dbs_directory}")
+                self.logger.error(f"Failed to save {local_sign_file} to {self.dbs_directory}")
                 return CvdStatus.ERROR
 
         elif response.status_code == 304:
             # Not modified since IMS. We have the latest version.
-            self.logger.info(f"{sign_file} not-modified since: {ims} (local version {version})")
+            self.logger.info(f"{local_sign_file} not-modified since: {ims} (local version {version})")
             return CvdStatus.NO_UPDATE
 
         elif response.status_code == 429:
             # Rejected because downloading the same file too frequently.
-            self.logger.warning(f"Failed to download {sign_file} from {url} with 429 response.")
+            self.logger.warning(f"Failed to download {remote_sign_file} from {url} with 429 response.")
             return CvdStatus.ERROR
 
         else:

--- a/cvdupdate/cvdupdate.py
+++ b/cvdupdate/cvdupdate.py
@@ -927,8 +927,12 @@ class CVDUpdate:
 
             # Prune old CDIFFs if needed
             if len(self.state['dbs'][db]['CDIFFs']) > self.config['cdiffs_to_keep']:
+                oldest_cdiff = self.dbs_directory / self.state['dbs'][db]['CDIFFs'][0]
                 try:
-                    os.remove(self.dbs_directory / self.state['dbs'][db]['CDIFFs'][0])
+                    os.remove(oldest_cdiff)
+                    oldest_cdiff_sign = Path(str(oldest_cdiff) + ".sign")
+                    if oldest_cdiff_sign.exists():
+                        os.remove(oldest_cdiff_sign)
                 except Exception as exc:
                     self.logger.debug(f"EXCEPTION OCCURRED: {exc}")
                     self.logger.debug(f"Tried to prune old cdiffs, but they weren't found, maybe someone else removed them already.")
@@ -1409,9 +1413,14 @@ class CVDUpdate:
             return False
 
         try:
-            if (self.dbs_directory / db).exists():
-                os.remove(str(self.dbs_directory / db))
+            db_path = self.dbs_directory / db
+            if db_path.exists():
+                os.remove(str(db_path))
                 self.logger.info(f"Deleted {db} from database directory.")
+                db_sign_path = Path(str(db_path) + ".sign")
+                if db_sign_path.exists():
+                    os.remove(str(db_sign_path))
+                    self.logger.info(f"Deleted {db}.sign from database directory.")
 
         except Exception as exc:
             self.logger.debug(f"An exception occured: {exc}")
@@ -1419,9 +1428,14 @@ class CVDUpdate:
 
         for cdiff in self.state['dbs'][db]['CDIFFs']:
             try:
-                if (self.dbs_directory / cdiff).exists():
-                    os.remove(str(self.dbs_directory / cdiff))
+                cdiff_path = self.dbs_directory / cdiff
+                if cdiff_path.exists():
+                    os.remove(str(cdiff_path))
                     self.logger.info(f"Deleted {cdiff} from database directory.")
+                    cdiff_sign_path = Path(str(cdiff_path) + ".sign")
+                    if cdiff_sign_path.exists():
+                        os.remove(str(cdiff_sign_path))
+                        self.logger.info(f"Deleted {cdiff}.sign from database directory.")
 
             except Exception as exc:
                 self.logger.debug(f"An exception occured: {exc}")

--- a/tests/test_cvdupdate.py
+++ b/tests/test_cvdupdate.py
@@ -233,3 +233,80 @@ def test_sign_download_uses_origin_name_for_url_and_local_name_for_file(revert_h
     assert wrote['data'] == b'sigdata'
     # Confirm no file was actually created by this test.
     assert not real_exists(local_sign_path)
+
+
+def test_cdiff_rotation_removes_matching_sign_file(revert_homedir, tmp_path, monkeypatch):
+    db_dir = tmp_path / 'db'
+    db_dir.mkdir()
+
+    c = CVDUpdate(
+        config=str(tmp_path / 'config.json'),
+        state_file=str(tmp_path / 'state.json'),
+        dbs_directory=str(db_dir),
+        cdiffs_to_keep=1,
+    )
+
+    class FakeResponse:
+        status_code = 200
+        headers = {'content-length': '7'}
+        content = b'cdiff-1'
+
+    requested_urls = []
+
+    def fake_get(url, headers):
+        requested_urls.append(url)
+        return FakeResponse()
+
+    monkeypatch.setattr('cvdupdate.cvdupdate.requests.get', fake_get)
+
+    first_cdiff = db_dir / 'daily-1.cdiff'
+    first_sign = db_dir / 'daily-1.cdiff.sign'
+    first_cdiff.write_bytes(b'cdiff-1')
+    first_sign.write_bytes(b'sign-1')
+    c.state['dbs']['daily.cvd']['CDIFFs'] = ['daily-1.cdiff']
+
+    result = c._download_cdiff(
+        db='daily.cvd',
+        file='daily-2.cdiff',
+        db_url='https://database.clamav.net/daily.cvd',
+        last_modified=0,
+        desired_version=2,
+        available_version=2,
+    )
+
+    assert result == CvdStatus.UPDATED
+    assert not first_cdiff.exists()
+    assert not first_sign.exists()
+    assert (db_dir / 'daily-2.cdiff').exists()
+    assert c.state['dbs']['daily.cvd']['CDIFFs'] == ['daily-2.cdiff']
+    assert requested_urls == ['https://database.clamav.net/daily-2.cdiff']
+
+
+def test_config_remove_db_removes_database_and_related_sign_files(revert_homedir, tmp_path):
+    db_dir = tmp_path / 'db'
+    db_dir.mkdir()
+
+    c = CVDUpdate(
+        config=str(tmp_path / 'config.json'),
+        state_file=str(tmp_path / 'state.json'),
+        dbs_directory=str(db_dir),
+    )
+
+    db_path = db_dir / 'daily.cvd'
+    db_sign_path = db_dir / 'daily.cvd.sign'
+    cdiff_path = db_dir / 'daily-1.cdiff'
+    cdiff_sign_path = db_dir / 'daily-1.cdiff.sign'
+
+    db_path.write_bytes(b'db')
+    db_sign_path.write_bytes(b'db-sign')
+    cdiff_path.write_bytes(b'cdiff')
+    cdiff_sign_path.write_bytes(b'cdiff-sign')
+    c.state['dbs']['daily.cvd']['CDIFFs'] = ['daily-1.cdiff']
+
+    assert c.config_remove_db('daily.cvd') is True
+
+    assert not db_path.exists()
+    assert not db_sign_path.exists()
+    assert not cdiff_path.exists()
+    assert not cdiff_sign_path.exists()
+    assert 'daily.cvd' not in c.state['dbs']

--- a/tests/test_cvdupdate.py
+++ b/tests/test_cvdupdate.py
@@ -1,10 +1,12 @@
 import json
 import datetime
+import socket
 from pathlib import Path
+from typing import Any
 
 from tests.fixtures.revert import revert_homedir
 
-from cvdupdate.cvdupdate import CVDUpdate
+from cvdupdate.cvdupdate import CVDUpdate, CvdStatus
 
 def test_instantiation(revert_homedir):
     c = CVDUpdate()
@@ -156,3 +158,78 @@ def test_v1_config_migrates_successfully(revert_homedir):
     with Path(disk_config['state_file']).open() as f:
         disk_state = json.load(f)
     assert disk_state == a.state
+
+
+def test_sign_download_uses_origin_name_for_url_and_local_name_for_file(revert_homedir, tmp_path, monkeypatch):
+    db_dir = tmp_path / 'db'
+    db_dir.mkdir()
+
+    c = CVDUpdate(
+        config=str(tmp_path / 'config.json'),
+        state_file=str(tmp_path / 'state.json'),
+        dbs_directory=str(db_dir),
+    )
+
+    called = {}
+
+    class FakeResponse:
+        status_code = 200
+        content = b'sigdata'
+        headers = {'content-length': str(len(content))}
+
+    def fake_get(url, headers):
+        called['url'] = url
+        called['headers'] = headers
+        return FakeResponse()
+
+    def fail_network(*args, **kwargs):
+        raise AssertionError('Real network usage is forbidden in this test')
+
+    local_sign_path = db_dir / 'local-main.cvd.sign'
+    real_exists = Path.exists
+    real_open = Path.open
+    wrote: dict[str, Any] = {}
+
+    class FakeBinaryWriter:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def write(self, data: bytes) -> int:
+            wrote['data'] = data
+            return len(data)
+
+    def fake_exists(self):
+        if self == local_sign_path:
+            # Force the code path that performs the download + save.
+            return False
+        return real_exists(self)
+
+    def fake_open(self, mode='r', *args, **kwargs):
+        if self == local_sign_path and mode == 'wb':
+            wrote['opened'] = True
+            return FakeBinaryWriter()
+        return real_open(self, mode, *args, **kwargs)
+
+    monkeypatch.setattr('cvdupdate.cvdupdate.requests.get', fake_get)
+    # Hard guard: if anything tries to open a real socket.
+    monkeypatch.setattr(socket.socket, 'connect', fail_network)
+    monkeypatch.setattr(socket.socket, 'connect_ex', fail_network)
+    monkeypatch.setattr(Path, 'exists', fake_exists)
+    monkeypatch.setattr(Path, 'open', fake_open)
+
+    status = c._download_sign_file_for(
+        file='local-main.cvd',
+        file_url='https://database.clamav.net/main.cvd?version=12345',
+        last_modified=0,
+        version=12345,
+    )
+
+    assert status == CvdStatus.UPDATED
+    assert called['url'] == 'https://database.clamav.net/main-12345.cvd.sign'
+    assert wrote['opened'] is True
+    assert wrote['data'] == b'sigdata'
+    # Confirm no file was actually created by this test.
+    assert not real_exists(local_sign_path)


### PR DESCRIPTION
- decouple remote signature filename from local DB alias
- derive remote sign name from origin URL path, preserving versioned naming
- keep local save path as <local-db-name>.sign
- add regression coverage for local-name vs origin-name behavior
- harden test isolation with mocked HTTP and socket-level network guard
- remove sign files on cdiff retention
- remove sign files on database removal, including sign for cdiff versions